### PR TITLE
Add crypto powerdata tools to CLI and configuration

### DIFF
--- a/cli/commands.py
+++ b/cli/commands.py
@@ -283,7 +283,9 @@ class SpoonAICLI:
                           any(tool.name == crypto_name for crypto_name in [
                               "get_token_price", "get_24h_stats", "get_kline_data",
                               "price_threshold_alert", "lp_range_check", "monitor_sudden_price_increase",
-                              "lending_rate_monitor", "crypto_market_monitor", "predict_price", "token_holders"
+                              "lending_rate_monitor", "crypto_market_monitor", "predict_price", "token_holders",
+                              "crypto_powerdata_cex", "crypto_powerdata_dex",
+                              "crypto_powerdata_indicators", "crypto_powerdata_price"
                           ])]
 
             if crypto_tools:

--- a/spoon_ai/tools/crypto_tools.py
+++ b/spoon_ai/tools/crypto_tools.py
@@ -38,6 +38,14 @@ def get_crypto_tools() -> List[BaseTool]:
         from spoon_toolkits.crypto.predict_price import PredictPrice
         from spoon_toolkits.crypto.token_holders import TokenHolders
 
+        # Import crypto_powerdata tools from spoon-toolkit
+        from spoon_toolkits.crypto_powerdata import (
+            CryptoPowerDataCEXTool,
+            CryptoPowerDataDEXTool,
+            CryptoPowerDataIndicatorsTool,
+            CryptoPowerDataPriceTool,
+        )
+
         # Instantiate all crypto tools
         tool_classes = [
             GetTokenPriceTool,
@@ -49,7 +57,11 @@ def get_crypto_tools() -> List[BaseTool]:
             LendingRateMonitorTool,
             CryptoMarketMonitor,
             PredictPrice,
-            TokenHolders
+            TokenHolders,
+            CryptoPowerDataCEXTool,
+            CryptoPowerDataDEXTool,
+            CryptoPowerDataIndicatorsTool,
+            CryptoPowerDataPriceTool,
         ]
 
         for tool_class in tool_classes:
@@ -117,14 +129,21 @@ class CryptoToolsConfig:
         "lending_rate_monitor",
         "crypto_market_monitor",
         "predict_price",
-        "token_holders"
+        "token_holders",
+        "crypto_powerdata_cex",
+        "crypto_powerdata_dex",
+        "crypto_powerdata_indicators",
+        "crypto_powerdata_price",
     ]
 
     # Tools that require special configuration
     TOOLS_REQUIRING_CONFIG = [
         "lending_rate_monitor",  # May need API keys
         "predict_price",         # Requires ML dependencies
-        "token_holders"          # Requires Bitquery API key
+        "token_holders",          # Requires Bitquery API key
+        "crypto_powerdata_cex", # May need API keys for private data
+        "crypto_powerdata_dex", # Requires OKX API Key
+        "crypto_powerdata_price", # Requires OKX/CEX API Keys
     ]
 
     @classmethod


### PR DESCRIPTION
- Updated CLI commands to include new crypto powerdata tools: CryptoPowerDataCEXTool, CryptoPowerDataDEXTool, CryptoPowerDataIndicatorsTool, and CryptoPowerDataPriceTool.
- Enhanced the get_crypto_tools function to instantiate these new tools.
- Updated configuration settings to include the new tools and their API key requirements.