### PR TITLE
feat(agent): introduce configuration-driven agent management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,12 @@ GITHUB_TOKEN=your-github-token
 GO_PLUS_LABS_APP_KEY=your-goplus-labs-app-key
 GO_PLUS_LABS_APP_SECRET=your-goplus-labs-app-secret
 
+# Bitquery (for blockchain data analysis)
+# Get these from https://bitquery.io/dashboard
+BITQUERY_API_KEY=your-bitquery-api-key
+BITQUERY_CLIENT_ID=your-bitquery-client-id
+BITQUERY_CLIENT_SECRET=your-bitquery-client-secret
+
 # ======= Logging Configuration =======
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
 LOG_LEVEL=INFO

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -7,7 +7,7 @@ import shlex
 import sys
 import traceback
 from pathlib import Path
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Any
 
 from prompt_toolkit import PromptSession, print_formatted_text
 from prompt_toolkit.completion import WordCompleter
@@ -256,21 +256,348 @@ class SpoonAICLI:
         name = input_list[0]
         self._load_agent(name)
 
-    def  _load_agent(self, name: str):
-        if name == "react":
-            self.agents[name] = SpoonReactAI()
-            self.current_agent = self.agents[name]
-            # Add crypto tools to the agent
-            self._add_crypto_tools_to_agent(self.current_agent)
-            logger.info(f"Loaded agent: {self.current_agent.name}")
-        elif name == "spoon_react_mcp":
-            self.agents[name] = SpoonReactMCP()
-            self.current_agent = self.agents[name]
-            # Add crypto tools to the agent
-            self._add_crypto_tools_to_agent(self.current_agent)
-            logger.info(f"Loaded agent: {self.current_agent.name}")
+    def _get_available_agents(self) -> Dict[str, Dict[str, Any]]:
+        """Get available agents from configuration and built-in definitions"""
+        # Built-in agent definitions
+        builtin_agents = {
+            "react": {
+                "class": "SpoonReactAI",
+                "aliases": ["spoon_react"],
+                "description": "A smart AI agent for blockchain operations"
+            },
+            "spoon_react_mcp": {
+                "class": "SpoonReactMCP",
+                "aliases": [],
+                "description": "SpoonReact agent with MCP protocol support"
+            }
+        }
+
+        # Get agents from configuration file
+        config_agents = self.config_manager.get("agents", {})
+
+        # Merge built-in and config agents (config takes precedence)
+        available_agents = {**builtin_agents, **config_agents}
+
+        return available_agents
+
+    def _load_agent(self, name: str):
+        """Load agent by name using configuration-driven approach"""
+        available_agents = self._get_available_agents()
+
+        # Find agent by name or alias
+        agent_config = None
+        agent_key = None
+
+        # Direct name match
+        if name in available_agents:
+            agent_config = available_agents[name]
+            agent_key = name
         else:
+            # Search by alias
+            for key, config in available_agents.items():
+                if name in config.get("aliases", []):
+                    agent_config = config
+                    agent_key = key
+                    break
+
+        if not agent_config:
             logger.error(f"Agent {name} not found")
+            logger.info("Available agents:")
+            for key, config in available_agents.items():
+                aliases = config.get("aliases", [])
+                alias_str = f" (aliases: {', '.join(aliases)})" if aliases else ""
+                logger.info(f"  {key}{alias_str}: {config.get('description', 'No description')}")
+            return
+
+        # Load agent based on class name
+        agent_class = agent_config.get("class")
+        try:
+            # Create agent instance with configuration
+            agent_instance_config = agent_config.get("config", {})
+
+            if agent_class == "SpoonReactAI":
+                self.agents[name] = SpoonReactAI(**agent_instance_config)
+            elif agent_class == "SpoonReactMCP":
+                # For MCP agents, configure MCP servers and transports
+                mcp_config = self._prepare_mcp_config(agent_config)
+                logger.info(f"Creating MCP agent with config: {mcp_config}")
+
+                # Create MCP agent with proper transport configuration
+                if mcp_config.get("mcp_servers"):
+                    # Create primary transport for the first enabled MCP server
+                    mcp_transport = self._create_mcp_transport(mcp_config)
+                    self.agents[name] = SpoonReactMCP(mcp_transport=mcp_transport, **agent_instance_config)
+
+                    # Store MCP configuration for later use by the agent
+                    self.agents[name]._mcp_config = mcp_config
+                else:
+                    # No MCP servers configured, use default
+                    logger.warning(f"No MCP servers configured for agent {name}, using default transport")
+                    self.agents[name] = SpoonReactMCP(**agent_instance_config)
+            else:
+                logger.error(f"Unknown agent class: {agent_class}")
+                return
+
+            self.current_agent = self.agents[name]
+
+            # Configure tools for the agent
+            self._configure_agent_tools(self.current_agent, agent_config)
+
+            # Add crypto tools to the agent (default behavior)
+            self._add_crypto_tools_to_agent(self.current_agent)
+
+            logger.info(f"Loaded agent: {self.current_agent.name}")
+
+        except Exception as e:
+            logger.error(f"Failed to load agent {name}: {e}")
+            logger.debug(f"Agent loading error details: {e}", exc_info=True)
+
+    def _prepare_mcp_config(self, agent_config: Dict[str, Any]) -> Dict[str, Any]:
+        """Prepare MCP configuration for MCP-enabled agents"""
+        mcp_config = {}
+
+        # Get MCP servers configuration
+        mcp_servers = agent_config.get("mcp_servers", [])
+        if mcp_servers:
+            servers_config = self.config_manager.get("mcp_servers", {})
+            mcp_config["mcp_servers"] = {}
+
+            for server_name in mcp_servers:
+                if server_name in servers_config:
+                    server_config = servers_config[server_name]
+                    if not server_config.get("disabled", False):
+                        mcp_config["mcp_servers"][server_name] = server_config
+                        logger.info(f"Configured MCP server: {server_name}")
+                    else:
+                        logger.warning(f"MCP server {server_name} is disabled")
+                else:
+                    logger.warning(f"MCP server {server_name} not found in configuration")
+
+        return mcp_config
+
+    def _create_mcp_transport(self, mcp_config: Dict[str, Any]):
+        """Create MCP transport based on server configuration with universal support"""
+        from fastmcp.client.transports import (
+            NpxStdioTransport, PythonStdioTransport, SSETransport,
+            WSTransport, FastMCPStdioTransport, UvxStdioTransport
+        )
+
+        mcp_servers = mcp_config.get("mcp_servers", {})
+
+        # Support multiple MCP servers - use the first configured one for now
+        # In the future, we can support multiple simultaneous connections
+        for server_name, server_config in mcp_servers.items():
+            if server_config.get("disabled", False):
+                logger.info(f"Skipping disabled MCP server: {server_name}")
+                continue
+
+            transport_type = server_config.get("transport", "auto")
+            logger.info(f"Creating MCP transport for {server_name} (type: {transport_type})")
+
+            try:
+                transport = self._create_transport_by_type(server_name, server_config, transport_type)
+                if transport:
+                    logger.info(f"Successfully created {transport_type} transport for {server_name}")
+                    return transport
+            except Exception as e:
+                logger.error(f"Failed to create transport for {server_name}: {e}")
+                continue
+
+        # Fallback to default transport
+        logger.info("Using fallback SSE transport")
+        return SSETransport("http://127.0.0.1:8765/sse")
+
+    def _create_transport_by_type(self, server_name: str, server_config: Dict[str, Any], transport_type: str):
+        """Create specific transport type based on configuration"""
+        from fastmcp.client.transports import (
+            NpxStdioTransport, PythonStdioTransport, SSETransport,
+            WSTransport, FastMCPStdioTransport, UvxStdioTransport
+        )
+
+        # Auto-detect transport type if not specified
+        if transport_type == "auto":
+            transport_type = self._detect_transport_type(server_config)
+
+        env_vars = server_config.get("env", {})
+
+        if transport_type == "npx" or (transport_type == "stdio" and server_config.get("command") == "npx"):
+            return self._create_npx_transport(server_config, env_vars)
+
+        elif transport_type == "python" or (transport_type == "stdio" and server_config.get("command") == "python"):
+            return self._create_python_transport(server_config, env_vars)
+
+        elif transport_type == "uvx" or (transport_type == "stdio" and server_config.get("command") == "uvx"):
+            return self._create_uvx_transport(server_config, env_vars)
+
+        elif transport_type == "sse":
+            return self._create_sse_transport(server_config)
+
+        elif transport_type == "websocket" or transport_type == "ws":
+            return self._create_websocket_transport(server_config)
+
+        elif transport_type == "fastmcp":
+            return self._create_fastmcp_transport(server_config, env_vars)
+
+        else:
+            logger.warning(f"Unsupported transport type: {transport_type}")
+            return None
+
+    def _detect_transport_type(self, server_config: Dict[str, Any]) -> str:
+        """Auto-detect transport type based on server configuration"""
+        command = server_config.get("command", "")
+        url = server_config.get("url", "")
+
+        if command == "npx":
+            return "npx"
+        elif command == "python":
+            return "python"
+        elif command == "uvx":
+            return "uvx"
+        elif url.startswith("http") and "/sse" in url:
+            return "sse"
+        elif url.startswith("ws"):
+            return "websocket"
+        elif command:
+            return "stdio"  # Generic stdio for other commands
+        else:
+            return "sse"  # Default fallback
+
+    def _create_npx_transport(self, server_config: Dict[str, Any], env_vars: Dict[str, str]):
+        """Create NPX stdio transport"""
+        from fastmcp.client.transports import NpxStdioTransport
+
+        args = server_config.get("args", [])
+        if not args:
+            raise ValueError("NPX transport requires args with package name")
+
+        # Extract package name (usually the last argument)
+        package_name = args[-1]
+        package_args = args[:-1] if len(args) > 1 else []
+
+        logger.info(f"Creating NPX transport: package={package_name}, args={package_args}")
+
+        return NpxStdioTransport(
+            package=package_name,
+            args=package_args,
+            env_vars=env_vars,
+            project_directory=server_config.get("cwd"),
+            use_package_lock=server_config.get("use_package_lock", True)
+        )
+
+    def _create_python_transport(self, server_config: Dict[str, Any], env_vars: Dict[str, str]):
+        """Create Python stdio transport"""
+        from fastmcp.client.transports import PythonStdioTransport
+
+        script_path = server_config.get("script_path") or server_config.get("args", [None])[0]
+        if not script_path:
+            raise ValueError("Python transport requires script_path or first arg as script path")
+
+        args = server_config.get("args", [])[1:] if len(server_config.get("args", [])) > 1 else []
+
+        logger.info(f"Creating Python transport: script={script_path}, args={args}")
+
+        return PythonStdioTransport(
+            script_path=script_path,
+            args=args,
+            env=env_vars,
+            cwd=server_config.get("cwd"),
+            python_cmd=server_config.get("python_cmd", "python")
+        )
+
+    def _create_uvx_transport(self, server_config: Dict[str, Any], env_vars: Dict[str, str]):
+        """Create UVX stdio transport"""
+        from fastmcp.client.transports import UvxStdioTransport
+
+        args = server_config.get("args", [])
+        if not args:
+            raise ValueError("UVX transport requires args with package name")
+
+        package_name = args[-1]
+        package_args = args[:-1] if len(args) > 1 else []
+
+        logger.info(f"Creating UVX transport: package={package_name}, args={package_args}")
+
+        return UvxStdioTransport(
+            package=package_name,
+            args=package_args,
+            env_vars=env_vars
+        )
+
+    def _create_sse_transport(self, server_config: Dict[str, Any]):
+        """Create SSE transport"""
+        from fastmcp.client.transports import SSETransport
+
+        url = server_config.get("url")
+        if not url:
+            host = server_config.get("host", "127.0.0.1")
+            port = server_config.get("port", 8765)
+            path = server_config.get("path", "/sse")
+            url = f"http://{host}:{port}{path}"
+
+        logger.info(f"Creating SSE transport: {url}")
+
+        return SSETransport(url)
+
+    def _create_websocket_transport(self, server_config: Dict[str, Any]):
+        """Create WebSocket transport"""
+        from fastmcp.client.transports import WSTransport
+
+        url = server_config.get("url")
+        if not url:
+            host = server_config.get("host", "127.0.0.1")
+            port = server_config.get("port", 8765)
+            path = server_config.get("path", "/ws")
+            url = f"ws://{host}:{port}{path}"
+
+        logger.info(f"Creating WebSocket transport: {url}")
+
+        return WSTransport(url)
+
+    def _create_fastmcp_transport(self, server_config: Dict[str, Any], env_vars: Dict[str, str]):
+        """Create FastMCP stdio transport"""
+        from fastmcp.client.transports import FastMCPStdioTransport
+
+        command = server_config.get("command")
+        args = server_config.get("args", [])
+
+        if not command:
+            raise ValueError("FastMCP transport requires command")
+
+        logger.info(f"Creating FastMCP transport: {command} {' '.join(args)}")
+
+        return FastMCPStdioTransport(
+            command=command,
+            args=args,
+            env=env_vars,
+            cwd=server_config.get("cwd")
+        )
+
+    def _configure_agent_tools(self, agent, agent_config: Dict[str, Any]):
+        """Configure tools for the agent based on configuration"""
+        tools = agent_config.get("tools", [])
+        if not tools:
+            return
+
+        tool_sets_config = self.config_manager.get("tool_sets", {})
+
+        for tool_name in tools:
+            if tool_name in tool_sets_config:
+                tool_config = tool_sets_config[tool_name]
+                tool_type = tool_config.get("type")
+
+                if tool_type == "builtin":
+                    if tool_config.get("enabled", True):
+                        logger.info(f"Enabled built-in tool set: {tool_name}")
+                        # Built-in tools like crypto_tools are handled separately
+                elif tool_type == "mcp_server":
+                    server_name = tool_config.get("server")
+                    if server_name:
+                        logger.info(f"Configured MCP tool set: {tool_name} from server: {server_name}")
+                        # MCP tools will be loaded when the MCP server connects
+                else:
+                    logger.warning(f"Unknown tool type: {tool_type} for tool: {tool_name}")
+            else:
+                logger.warning(f"Tool set {tool_name} not found in configuration")
 
     def _add_crypto_tools_to_agent(self, agent):
         """Add crypto tools to the agent's tool manager."""
@@ -302,13 +629,33 @@ class SpoonAICLI:
             logger.debug(f"Crypto tools integration error details: {e}", exc_info=True)
 
     def _handle_list_agents(self, input_list: List[str]):
+        """List all available agents from configuration and built-in definitions"""
+        available_agents = self._get_available_agents()
+
         logger.info("Available agents:")
-        for agent in self.agents.values():
-            logger.info(f"  {agent.name}: {agent.description}")
+        for name, config in available_agents.items():
+            aliases = config.get("aliases", [])
+            alias_str = f" (aliases: {', '.join(aliases)})" if aliases else ""
+            description = config.get("description", "No description")
+            logger.info(f"  {name}{alias_str}: {description}")
+
+        # Also show currently loaded agents (avoid duplicates)
+        if self.agents:
+            logger.info("\nCurrently loaded agents:")
+            loaded_agents = {}
+            for agent_key, agent in self.agents.items():
+                # Use agent name as key to avoid duplicates
+                if agent.name not in loaded_agents:
+                    loaded_agents[agent.name] = agent
+
+            for agent in loaded_agents.values():
+                logger.info(f"  {agent.name}: {agent.description}")
 
     def _load_default_agent(self):
-        # self._load_agent("spoon_react_mcp")
-        self._load_agent("react")
+        """Load the default agent from configuration"""
+        default_agent = self.config_manager.get("default_agent", "react")
+        logger.info(f"Loading default agent: {default_agent}")
+        self._load_agent(default_agent)
 
     def _set_prompt_toolkit(self):
         self.style = Style.from_dict({
@@ -951,10 +1298,7 @@ class SpoonAICLI:
         logger.info("  config api_key anthropic sk-ant-xxxx")
         logger.info("  config default_agent my_agent")
 
-    def _handle_list_agents(self, input_list: List[str]):
-        logger.info("Available agents:")
-        for agent in self.agents.values():
-            logger.info(f"  {agent.name}: {agent.description}")
+
 
     def _handle_reload_config(self, input_list: List[str]):
         """Reload configuration"""

--- a/doc/agent.md
+++ b/doc/agent.md
@@ -8,11 +8,28 @@ SpoonOS adopts the ReAct (Reasoning + Acting) architecture, enabling the develop
 
 Every agent in SCDF extends from the BaseAgent class and follows the ReAct (Reasoning + Action) loop. Common types include:
 
-- ToolCallAgent: Automatically selects and calls tools based on the task.
+- **ToolCallAgent**: Automatically selects and calls tools based on the task.
+- **SpoonReactAI**: Standard agent with built-in crypto tools (no MCP support).
+- **SpoonReactMCP**: MCP-enabled agent that can connect to external services.
+- **CustomAgent**: Your own implementation with custom tools, logic, or control.
 
-- SpoonReactAI: A built-in example agent with OpenAI/Anthropic/DeepSeek support.
+### Agent Types Comparison
 
-- CustomAgent: Your own implementation with custom tools, logic, or control.
+| Agent Type | MCP Support | Use Case | Configuration |
+|------------|-------------|----------|---------------|
+| `SpoonReactAI` | ❌ | Standard blockchain operations | Built-in tools only |
+| `SpoonReactMCP` | ✅ | External service integration | Requires MCP server config |
+
+### Built-in Agents
+
+The following agents are built into the system:
+
+| Agent Name | Aliases | Type | Description |
+|------------|---------|------|-------------|
+| `react` | `spoon_react` | SpoonReactAI | Standard blockchain agent |
+| `spoon_react_mcp` | - | SpoonReactMCP | MCP-enabled blockchain agent |
+
+**Note**: Additional agents can be configured in `config.json` (see configuration examples below).
 
 ## 🔄 ReAct Agent Loop
 
@@ -82,6 +99,116 @@ class MyCustomAgent(ToolCallAgent):
         MyCustomTool(),
         # Add other tools...
     ]))
+```
+
+## ⚙️ Agent Configuration via config.json
+
+Instead of creating agents programmatically, you can configure them in `spoon-core/config.json` for use with the CLI.
+
+### Basic Agent Configuration
+
+```json
+{
+  "default_agent": "my_agent",
+  "agents": {
+    "my_agent": {
+      "class": "SpoonReactAI",
+      "aliases": ["my", "custom"],
+      "description": "My custom agent",
+      "config": {
+        "max_steps": 10,
+        "tool_choice": "auto"
+      },
+      "tools": ["crypto_tools"]
+    }
+  }
+}
+```
+
+### MCP-Enabled Agent Configuration Example
+
+Here's how to configure a custom agent with external service integration:
+
+```json
+{
+  "agents": {
+    "my_search_agent": {
+      "class": "SpoonReactMCP",
+      "aliases": ["search", "web"],
+      "description": "Custom agent with web search capabilities",
+      "config": {
+        "max_steps": 20,
+        "tool_choice": "auto"
+      },
+      "mcp_servers": ["tavily-mcp"],
+      "tools": ["web_search", "crypto_tools"]
+    }
+  },
+  "mcp_servers": {
+    "tavily-mcp": {
+      "transport": "npx",
+      "command": "npx",
+      "args": ["-y", "tavily-mcp"],
+      "env": {
+        "TAVILY_API_KEY": "your-api-key"
+      },
+      "disabled": false
+    }
+  },
+  "tool_sets": {
+    "web_search": {
+      "type": "mcp_server",
+      "server": "tavily-mcp",
+      "enabled": true
+    },
+    "crypto_tools": {
+      "type": "builtin",
+      "enabled": true
+    }
+  }
+}
+```
+
+### Configuration Parameters
+
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|---------|
+| `class` | string | Agent type: "SpoonReactAI" or "SpoonReactMCP" | `"SpoonReactMCP"` |
+| `aliases` | array | Alternative names for loading the agent | `["search", "web"]` |
+| `description` | string | Human-readable description | `"Web search agent"` |
+| `config.max_steps` | integer | Maximum reasoning steps (default: 10) | `20` |
+| `config.tool_choice` | string | Tool selection mode: "auto", "required", "none" | `"auto"` |
+| `mcp_servers` | array | MCP servers to connect to (MCP agents only) | `["tavily-mcp"]` |
+| `tools` | array | Tool sets to enable | `["web_search", "crypto_tools"]` |
+
+### MCP Server Configuration
+
+| Transport | Use Case | Required Fields | Example |
+|-----------|----------|-----------------|---------|
+| `npx` | Node.js packages | `command`, `args` | Tavily search |
+| `python` | Python scripts | `script_path` | Custom servers |
+| `sse` | HTTP streaming | `url` | Real-time data |
+| `websocket` | Real-time | `url` | Live connections |
+
+### Using Configured Agents
+
+Once configured, custom agents will appear in the CLI:
+
+```bash
+# List available agents (includes built-in + configured)
+> list-agents
+
+# Load built-in agent
+> load-agent react
+
+# Load custom configured agent by name
+> load-agent my_search_agent
+
+# Load custom agent by alias
+> load-agent search
+
+# Start conversation
+> action chat
 ```
 
 ## 🧪 Run the Agent

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -18,6 +18,34 @@ Once the MCP server is running, launch the CLI:
 python main.py
 ```
 
+## 📋 Available Agents
+
+The CLI includes these built-in agents:
+
+| Agent | Aliases | Type | MCP Support | Description |
+|-------|---------|------|-------------|-------------|
+| `react` | `spoon_react` | SpoonReactAI | ❌ | Standard blockchain analysis agent |
+| `spoon_react_mcp` | - | SpoonReactMCP | ✅ | MCP-enabled blockchain agent |
+
+**Note**: Additional agents can be configured in `config.json` (see examples below).
+
+### Loading Agents
+
+```bash
+# List all available agents
+> list-agents
+
+# Load built-in agent by name
+> load-agent react
+> load-agent spoon_react_mcp
+
+# Load agent by alias
+> load-agent spoon_react
+
+# Check currently loaded agent
+> list-agents
+```
+
 ## Basic Commands
 
 | Command             | Aliases           | Description                                                                                                               |
@@ -52,6 +80,70 @@ python main.py
 | Command                      | Aliases | Description                                                      |
 | ---------------------------- | ------- | ---------------------------------------------------------------- |
 | `load-docs <directory_path>` | `docs`  | Load documents from the specified directory to the current agent |
+
+## ⚙️ Configuration Management
+
+### Environment Variables
+
+Set required API keys before starting:
+
+```bash
+# Required for web search (Tavily MCP)
+export TAVILY_API_KEY="your-tavily-api-key"
+
+# Required for LLM functionality
+export OPENAI_API_KEY="your-openai-api-key"
+
+# Optional: Debug mode
+export DEBUG=true
+export LOG_LEVEL=debug
+```
+
+### Agent Configuration
+
+Custom agents can be configured in `spoon-core/config.json`. The basic structure is:
+
+```json
+{
+  "default_agent": "react",
+  "agents": {
+    "my_custom_agent": {
+      "class": "SpoonReactAI",
+      "aliases": ["my", "custom"],
+      "description": "My custom agent",
+      "config": {
+        "max_steps": 10,
+        "tool_choice": "auto"
+      },
+      "tools": ["crypto_tools"]
+    }
+  }
+}
+```
+
+For MCP-enabled agents, additional configuration is needed (see examples below).
+
+### MCP Server Types
+
+| Transport | Use Case | Configuration Example |
+|-----------|----------|----------------------|
+| `npx` | Node.js packages | `"command": "npx", "args": ["-y", "package-name"]` |
+| `python` | Python scripts | `"script_path": "server.py", "args": ["--port", "8766"]` |
+| `sse` | HTTP streaming | `"url": "http://localhost:8765/sse"` |
+| `websocket` | Real-time | `"url": "ws://localhost:8765/ws"` |
+
+### Configuration Commands
+
+```bash
+# Reload configuration after changes
+> reload-config
+
+# Check current configuration
+> config
+
+# Update specific settings
+> config API_KEY your-new-key
+```
 
 ## CLI Usage Examples
 
@@ -110,6 +202,79 @@ Decimals: 18
 > transfer 0x123... 0.1 SPO
 Preparing to transfer 0.1 SPO to 0x123...
 [Transfer details will be displayed here]
+```
+
+## 🔧 Troubleshooting
+
+### Common Issues
+
+| Issue | Symptoms | Solution |
+|-------|----------|----------|
+| **Agent not found** | `Agent 'name' not found` | Use `list-agents` to check available agents, verify spelling |
+| **MCP connection failed** | `Failed to create transport` | Check API keys, verify MCP server is running |
+| **Tool not available** | `Tool 'name' not found` | Check `tool_sets` config, verify MCP server enabled |
+| **Duplicate agents** | Same agent appears twice | Fixed in latest version, restart if needed |
+| **API key missing** | Authentication errors | Set environment variables: `TAVILY_API_KEY`, `OPENAI_API_KEY` |
+
+### Debug Mode
+
+Enable detailed logging:
+
+```bash
+export DEBUG=true
+export LOG_LEVEL=debug
+python main.py
+```
+
+### Configuration Validation
+
+1. **Check JSON syntax**: Use a JSON validator for `config.json`
+2. **Verify required fields**: Ensure all required parameters are present
+3. **Test MCP servers**: Verify external services are accessible
+4. **Check environment variables**: Confirm all API keys are set
+
+### Example: Custom Search Agent Configuration
+
+Here's how to configure a custom search agent with MCP integration:
+
+```json
+{
+  "default_agent": "my_search_agent",
+  "agents": {
+    "my_search_agent": {
+      "class": "SpoonReactMCP",
+      "aliases": ["search", "web"],
+      "description": "Custom search agent with web capabilities",
+      "mcp_servers": ["tavily-mcp"],
+      "tools": ["web_search", "crypto_tools"]
+    }
+  },
+  "mcp_servers": {
+    "tavily-mcp": {
+      "transport": "npx",
+      "command": "npx",
+      "args": ["-y", "tavily-mcp"],
+      "env": { "TAVILY_API_KEY": "your-key" }
+    }
+  },
+  "tool_sets": {
+    "web_search": {
+      "type": "mcp_server",
+      "server": "tavily-mcp",
+      "enabled": true
+    },
+    "crypto_tools": {
+      "type": "builtin",
+      "enabled": true
+    }
+  }
+}
+```
+
+After adding this configuration, the agent will appear in `list-agents` and can be loaded with:
+```bash
+> load-agent my_search_agent
+> load-agent search  # using alias
 ```
 
 ## ✅ Next Steps

--- a/spoon_ai/agents/mcp_client_mixin.py
+++ b/spoon_ai/agents/mcp_client_mixin.py
@@ -4,39 +4,40 @@ import uuid
 from contextlib import asynccontextmanager
 
 from fastmcp.client.transports import (FastMCPTransport, PythonStdioTransport,
-                                       SSETransport, WSTransport)
+                                       SSETransport, WSTransport, NpxStdioTransport,
+                                       FastMCPStdioTransport, UvxStdioTransport)
 from fastmcp.client import Client as MCPClient
 import logging
 
 logger = logging.getLogger(__name__)
 
 class MCPClientMixin:
-    def __init__(self, mcp_transport: Union[str, WSTransport, SSETransport, PythonStdioTransport, FastMCPTransport]):
+    def __init__(self, mcp_transport: Union[str, WSTransport, SSETransport, PythonStdioTransport, NpxStdioTransport, FastMCPTransport, FastMCPStdioTransport, UvxStdioTransport]):
         self.mcp_transport = mcp_transport
         self._client = MCPClient(self.mcp_transport)
         self._last_sender = None
         self._last_topic = None
         self._last_message_id = None
         self.output_topic = None
-        
+
         # We'll keep track of the active client session
         self._active_session = None
         self._session_lock = asyncio.Lock()
         # save the session for each task
         self._task_sessions = {}
-    
+
     @asynccontextmanager
     async def get_session(self):
         """
         Get a session to the MCP server using the proper context manager pattern.
         This follows the official usage: async with Client(...) as client
-        
+
         Yields:
             An active client session
         """
         # Generate a unique task ID using UUID
         task_id = id(asyncio.current_task())
-        
+
         # Check if the current task already has a session
         if task_id in self._task_sessions:
             try:
@@ -44,13 +45,13 @@ class MCPClientMixin:
             finally:
                 pass
             return
-        
+
         # If not, create a new session
         async with self._session_lock:
             # Create a new session for the current task
             session = await self._client.__aenter__()
             self._task_sessions[task_id] = session
-            
+
             try:
                 yield session
             finally:
@@ -62,39 +63,39 @@ class MCPClientMixin:
                 finally:
                     if task_id in self._task_sessions:
                         del self._task_sessions[task_id]
-    
+
     async def list_mcp_tools(self):
         """Get the list of available tools from the MCP server"""
         async with self.get_session() as session:
             return await session.list_tools()
-    
+
     async def call_mcp_tool(self, tool_name: str, **kwargs):
         """Call a tool on the MCP server"""
         async with self.get_session() as session:
             res = await session.call_tool(tool_name, arguments=kwargs)
             if not res:
                 return ""
-                
+
             for item in res:
                 if hasattr(item, 'text') and item.text is not None:
                     return item.text
-            
+
             if res:
                 return str(res[0])
-                
+
             return ""
-    
-    async def send_mcp_message(self, recipient: str, message: Union[str, Dict[str, Any]], 
+
+    async def send_mcp_message(self, recipient: str, message: Union[str, Dict[str, Any]],
                               topic: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> bool:
         """
         Send a message to the MCP system
-        
+
         Args:
             recipient: Recipient ID
             message: Message content (string or dictionary)
             topic: Message topic
             metadata: Additional metadata
-            
+
         Returns:
             bool: Whether the message was sent successfully
         """
@@ -107,7 +108,7 @@ class MCPClientMixin:
                 content["metadata"] = metadata
         else:
             content = message
-            
+
         try:
             async with self.get_session() as session:
                 await session.send_message(
@@ -119,45 +120,45 @@ class MCPClientMixin:
         except Exception as e:
             logger.error(f"Failed to send MCP message: {str(e)}")
             return False
-    
-    async def reply_to_mcp(self, message: str, topic: Optional[str] = None, 
+
+    async def reply_to_mcp(self, message: str, topic: Optional[str] = None,
                          metadata: Optional[Dict[str, Any]] = None) -> bool:
         """
         Reply to a previously received MCP message
-        
+
         Args:
             message: Reply content
             topic: Reply topic, defaults to the topic of the previous message
             metadata: Additional metadata
-            
+
         Returns:
             bool: Whether the reply was successful
         """
         if not hasattr(self, "_last_sender") or not self._last_sender:
             logger.warning(f"No previous sender to reply to")
             return False
-            
+
         recipient = self._last_sender
         reply_topic = topic or self._last_topic or "general"
-        
+
         reply_metadata = {
             "reply_to": self._last_message_id
         }
-        
+
         if metadata:
             reply_metadata.update(metadata)
-            
+
         return await self.send_mcp_message(
             recipient=recipient,
             message=message,
             topic=reply_topic,
             metadata=reply_metadata
         )
-    
+
     async def process_mcp_message(self, content: Any, sender: str, message: Dict[str, Any]):
         """
         Process a message received from the MCP system (should be overridden by subclasses)
-        
+
         Args:
             content: Message content
             sender: Sender ID
@@ -169,14 +170,14 @@ class MCPClientMixin:
             text_content = content
         else:
             text_content = str(content)
-            
+
         self._last_sender = sender
         self._last_topic = message.get("topic", "general")
         self._last_message_id = message.get("id")
-        
+
         # This method should be overridden by subclasses to handle messages
         logger.info(f"Received MCP message from {sender}: {text_content[:50]}{'...' if len(text_content) > 50 else ''}")
-        
+
     async def connect(self):
         """
         Establish a connection to the MCP server (this just creates a session to verify connection)
@@ -189,7 +190,7 @@ class MCPClientMixin:
         except Exception as e:
             logger.error(f"Failed to connect to MCP server: {str(e)}")
             raise
-            
+
     async def cleanup(self):
         """
         Clean up resources (no explicit disconnection needed with context manager pattern)

--- a/spoon_ai/agents/spoon_react.py
+++ b/spoon_ai/agents/spoon_react.py
@@ -1,7 +1,8 @@
 from typing import List, Union, Any, Dict, Optional
 import asyncio
 from fastmcp.client.transports import (FastMCPTransport, PythonStdioTransport,
-                                       SSETransport, WSTransport)
+                                       SSETransport, WSTransport, NpxStdioTransport,
+                                       FastMCPStdioTransport, UvxStdioTransport)
 from fastmcp.client import Client as MCPClient
 from pydantic import Field
 import logging
@@ -36,7 +37,7 @@ class SpoonReactAI(ToolCallAgent):
     avaliable_tools: ToolManager = Field(default_factory=lambda: ToolManager([]))
     llm: ChatBot = Field(default_factory=create_configured_chatbot)
 
-    mcp_transport: Union[str, WSTransport, SSETransport, PythonStdioTransport, FastMCPTransport] = Field(default="mcp_server")
+    mcp_transport: Union[str, WSTransport, SSETransport, PythonStdioTransport, NpxStdioTransport, FastMCPTransport, FastMCPStdioTransport, UvxStdioTransport] = Field(default="mcp_server")
     mcp_topics: List[str] = Field(default=["spoon_react"])
 
     def __init__(self, **kwargs):

--- a/spoon_ai/agents/toolcall.py
+++ b/spoon_ai/agents/toolcall.py
@@ -98,17 +98,18 @@ class ToolCallAgent(ReActAgent):
             output_queue=self.output_queue,
         )
 
-        # Check for finish_reason termination before processing tools
-        if self._should_terminate_on_finish_reason(response):
-            logger.info(f"🏁 {self.name} terminating due to finish_reason signals")
+        self.tool_calls = response.tool_calls
+
+        # Only terminate on finish_reason if there are NO tool calls
+        # If there are tool calls, we should execute them regardless of finish_reason
+        if not self.tool_calls and self._should_terminate_on_finish_reason(response):
+            logger.info(f"🏁 {self.name} terminating due to finish_reason signals (no tool calls)")
             self.state = AgentState.FINISHED
             self.add_message("assistant", response.content or "Task completed")
             # Set a flag to indicate finish_reason termination and store the content
             self._finish_reason_terminated = True
             self._final_response_content = response.content or "Task completed"
             return False
-
-        self.tool_calls = response.tool_calls
 
         logger.info(colored(f"🤔 {self.name}'s thoughts: {response.content}", "cyan"))
         tool_count = len(self.tool_calls) if self.tool_calls else 0

--- a/spoon_ai/utils/config_manager.py
+++ b/spoon_ai/utils/config_manager.py
@@ -20,12 +20,19 @@ class ConfigManager:
             if self.config_file.exists():
                 with open(self.config_file, 'r') as f:
                     return json.load(f)
+            else:
+                # Return default configuration if file doesn't exist
+                return {
+                    "api_keys": {},
+                    "base_url": "",
+                    "default_agent": "react"
+                }
         except Exception as e:
             print(f"Error loading config: {e}")
             return {
                 "api_keys": {},
                 "base_url": "",
-                "default_agent": "default"
+                "default_agent": "react"
             }
 
     def _is_placeholder_value(self, value: str) -> bool:


### PR DESCRIPTION
Refactors agent loading to be driven by `config.json`, moving away from a hard-coded system. This allows users to define custom agents with specific tools, aliases, and MCP server connections without modifying the core source code.

Key changes:
- The `load-agent` command now discovers and loads agents from both built-in definitions and `config.json`.
- Agents can be configured with aliases, descriptions, specific tools, and MCP server connections.
- The `list-agents` command displays all available agents, both built-in and user-configured.
- Added extensive support for various MCP transport types (`npx`, `python`, `uvx`, `stdio`, `sse`, `ws`) to facilitate integration with external services.
- The default agent is now configurable in `config.json`.
- Documentation is updated with examples and guides for the new agent configuration system.

fix: This commit also corrects an issue in the `ToolCallAgent` where it would terminate based on a model's `finish_reason` even when there were pending tool calls, ensuring tools are always executed when requested.