### PR TITLE
Fixed Timestamp Inconsistency in MonitoringTaskManager

### DIFF
--- a/spoon_ai/monitoring/core/tasks.py
+++ b/spoon_ai/monitoring/core/tasks.py
@@ -32,14 +32,15 @@ class MonitoringTaskManager:
         # Validate configuration
         self._validate_config(config)
         
-        # Set expiration time (default 24 hours)
+        # Create timestamps once to ensure consistency
+        creation_time = datetime.now()
         expires_in_hours = config.get("expires_in_hours", 24)
-        expiry_time = datetime.now() + timedelta(hours=expires_in_hours)
+        expiry_time = creation_time + timedelta(hours=expires_in_hours)
         
         # Store task metadata
         self.tasks[task_id] = {
             "status": TaskStatus.ACTIVE,
-            "created_at": datetime.now(),
+            "created_at": creation_time,
             "expires_at": expiry_time,
             "config": config,
             "last_checked": None,
@@ -66,7 +67,7 @@ class MonitoringTaskManager:
         self._task_wrapper(task_id, config)
         return {
             "task_id": task_id,
-            "created_at": datetime.now().isoformat(),
+            "created_at": creation_time.isoformat(),
             "expires_at": expiry_time.isoformat(),
             "config": config,
             "status": TaskStatus.ACTIVE


### PR DESCRIPTION
## Summary
Fixes timestamp inconsistency bug where `create_task()` method was calling `datetime.now()` multiple times, causing stored task metadata and API response to have different creation timestamps.

**Fixes:** #[91] - Timestamp Inconsistency in MonitoringTaskManager.create_task()

## Problem
The `create_task` method in `MonitoringTaskManager` was calling `datetime.now()` at three different points:
1. When calculating expiry time
2. When storing task metadata 
3. When returning the API response

This created inconsistent timestamps between stored data and API responses, violating data consistency principles.

## Solution
- **Single timestamp creation**: Store `datetime.now()` in `creation_time` variable
- **Consistent usage**: Use the same `creation_time` for both storage and response
- **Improved expiry calculation**: Base expiry time on the same creation timestamp

## Changes Made

### File: `spoon_ai/monitoring/core/tasks.py`

**Before:**
```python
def create_task(self, config: Dict[str, Any]) -> Dict[str, Any]:
    # ...
    expires_in_hours = config.get("expires_in_hours", 24)
    expiry_time = datetime.now() + timedelta(hours=expires_in_hours)  # Call #1
    
    self.tasks[task_id] = {
        "created_at": datetime.now(),  # Call #2 - Different time!
        "expires_at": expiry_time,
        # ...
    }
    
    return {
        "created_at": datetime.now().isoformat(),  # Call #3 - Even more different!
        "expires_at": expiry_time.isoformat(),
        # ...
    }
```

**After:**
```python
def create_task(self, config: Dict[str, Any]) -> Dict[str, Any]:
    # ...
    # Create timestamps once to ensure consistency
    creation_time = datetime.now()  # Single source of truth
    expires_in_hours = config.get("expires_in_hours", 24)
    expiry_time = creation_time + timedelta(hours=expires_in_hours)
    
    self.tasks[task_id] = {
        "created_at": creation_time,  # Uses consistent timestamp
        "expires_at": expiry_time,
        # ...
    }
    
    return {
        "created_at": creation_time.isoformat(),  # Same timestamp
        "expires_at": expiry_time.isoformat(),
        # ...
    }
```

## Benefits

### ✅ **Data Consistency**
- Stored task metadata and API response now have identical timestamps
- Eliminates confusion in debugging and monitoring

### ✅ **Performance Improvement**
- Reduced from 3 `datetime.now()` system calls to 1
- Slight performance boost in task creation

### ✅ **Code Quality**
- Single source of truth for creation time
- More maintainable and less error-prone

### ✅ **Future-proof**
- Eliminates potential timing-related bugs
- Better foundation for time-based calculations

## Testing

### Manual Testing
1. ✅ Created monitoring task via API
2. ✅ Verified stored metadata timestamp matches response timestamp
3. ✅ Confirmed expiry time calculation uses consistent base time

### Regression Testing
1. ✅ All existing functionality works unchanged
2. ✅ Task creation, scheduling, and expiry work as expected
3. ✅ No breaking changes to API contract

### Recommended Test Case
```python
def test_create_task_timestamp_consistency():
    """Test that stored and returned timestamps are identical"""
    manager = MonitoringTaskManager()
    config = {
        "provider": "bn",
        "symbol": "BTCUSDT", 
        "metric": "price",
        "threshold": 50000,
        "comparator": ">"
    }
    
    # Create task
    response = manager.create_task(config)
    task_id = response["task_id"]
    
    # Get stored task
    stored_task = manager.get_task(task_id)
    
    # Timestamps should be identical
    assert response["created_at"] == stored_task["created_at"]
```

## Impact Assessment

### ✅ **Low Risk**
- Minimal code change with clear improvement
- No API contract changes
- Backward compatible

### ✅ **High Value**
- Fixes data consistency issue
- Improves system reliability
- Better developer experience

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No breaking changes
- [x] Functionality tested manually
- [x] Performance impact assessed (positive)

**Ready for review and merge** 🚀