### PR TITLE
chore(ci): update upload-artifact action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: twine check dist/*
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to use version 4 of the actions/upload-artifact action, ensuring compatibility with the latest features and improvements.