### PR TITLE
Refine X402 client challenge handling

### DIFF
--- a/spoon_ai/tools/__init__.py
+++ b/spoon_ai/tools/__init__.py
@@ -1,7 +1,9 @@
 from .tool_manager import ToolManager
 from .base import BaseTool
+from .x402_tool import X402RequestTool
 
 __all__ = [
     "ToolManager",
     "BaseTool",
+    "X402RequestTool",
 ]

--- a/spoon_ai/tools/x402_tool.py
+++ b/spoon_ai/tools/x402_tool.py
@@ -1,0 +1,104 @@
+"""Pydantic tool wrapper around :class:`~spoon_ai.x402.client.X402Client`."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Mapping, Optional
+
+import requests
+from pydantic import Field
+
+from spoon_ai.tools.base import BaseTool, ToolFailure, ToolResult
+from spoon_ai.x402 import X402Client
+
+
+class X402RequestTool(BaseTool):
+    """Agent tool that performs HTTP requests using X402 authentication."""
+
+    name: str = Field(default="x402_request", init=False)
+    description: str = Field(
+        default=(
+            "Perform an HTTP request against an endpoint protected by the X402 "
+            "protocol, automatically resolving challenges when possible."
+        ),
+        init=False,
+    )
+    parameters: Dict[str, Any] = Field(
+        default_factory=lambda: {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "The request URL."},
+                "method": {
+                    "type": "string",
+                    "description": "HTTP method to use (defaults to GET).",
+                    "default": "GET",
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Optional headers to include in the request.",
+                },
+                "json": {
+                    "description": "JSON payload to send with the request.",
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Query parameters to append to the request.",
+                },
+                "data": {
+                    "description": "Arbitrary data payload to include in the request.",
+                },
+                "timeout": {
+                    "type": ["number", "null"],
+                    "description": "Optional request timeout in seconds.",
+                },
+            },
+            "required": ["url"],
+            "additionalProperties": False,
+        },
+        init=False,
+    )
+
+    client: X402Client = Field(exclude=True)
+    default_timeout: Optional[float] = Field(default=None, exclude=True)
+
+    async def execute(
+        self,
+        *,
+        url: str,
+        method: str = "GET",
+        headers: Optional[Mapping[str, str]] = None,
+        params: Optional[Mapping[str, Any]] = None,
+        json: Optional[Any] = None,
+        data: Optional[Any] = None,
+        timeout: Optional[float] = None,
+    ) -> ToolResult:
+        method = method.upper()
+        timeout = timeout if timeout is not None else self.default_timeout
+
+        try:
+            response = await asyncio.to_thread(
+                self.client.request,
+                method,
+                url,
+                headers=dict(headers or {}),
+                params=params,
+                json=json,
+                data=data,
+                timeout=timeout,
+            )
+        except requests.RequestException as exc:  # pragma: no cover - network errors
+            raise ToolFailure(f"HTTP request failed: {exc}") from exc
+
+        content: Any
+        try:
+            content = response.json()
+        except ValueError:
+            content = response.text
+
+        return ToolResult(
+            output={
+                "status_code": response.status_code,
+                "headers": dict(response.headers),
+                "content": content,
+            }
+        )

--- a/spoon_ai/x402/__init__.py
+++ b/spoon_ai/x402/__init__.py
@@ -1,0 +1,19 @@
+"""Utilities for interacting with X402 authenticated services."""
+
+from .client import (
+    X402AuthenticationError,
+    X402Authorization,
+    X402Challenge,
+    X402Client,
+    X402PaymentProvider,
+    StaticX402PaymentProvider,
+)
+
+__all__ = [
+    "X402AuthenticationError",
+    "X402Authorization",
+    "X402Challenge",
+    "X402Client",
+    "X402PaymentProvider",
+    "StaticX402PaymentProvider",
+]

--- a/spoon_ai/x402/client.py
+++ b/spoon_ai/x402/client.py
@@ -1,0 +1,355 @@
+"""Client utilities for resolving X402 authentication challenges."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Mapping, MutableMapping, Optional, Protocol, Set, runtime_checkable
+from urllib.parse import urlparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class X402AuthenticationError(RuntimeError):
+    """Raised when an X402 authentication challenge cannot be fulfilled."""
+
+
+@dataclass(slots=True)
+class X402Authorization:
+    """Represents credentials that can satisfy an X402 challenge."""
+
+    token: Optional[str] = None
+    macaroon: Optional[str] = None
+    preimage: Optional[str] = None
+    scheme: str = "X-402"
+    expires_at: Optional[_dt.datetime] = None
+    extra: Dict[str, str] = field(default_factory=dict)
+
+    def as_header(self) -> str:
+        """Return the Authorization header value for the credentials."""
+        parts: Dict[str, str] = {}
+        if self.token:
+            parts["access_token"] = self.token
+        if self.macaroon:
+            parts["macaroon"] = self.macaroon
+        if self.preimage:
+            parts["preimage"] = self.preimage
+        parts.update(self.extra)
+        header_params = ", ".join(
+            f"{key}={_quote(value)}" for key, value in parts.items()
+        )
+        return f"{self.scheme} {header_params}" if header_params else self.scheme
+
+    def is_expired(self, *, now: Optional[_dt.datetime] = None) -> bool:
+        if self.expires_at is None:
+            return False
+        now = now or _dt.datetime.now(tz=_dt.timezone.utc)
+        return now >= self.expires_at
+
+
+@dataclass(slots=True)
+class X402Challenge:
+    """Parsed representation of an X402 challenge."""
+
+    scheme: str
+    params: Dict[str, str]
+    raw: str
+
+    @property
+    def realm(self) -> Optional[str]:
+        return self.params.get("realm")
+
+    @property
+    def invoice(self) -> Optional[str]:
+        return self.params.get("invoice")
+
+    @property
+    def macaroon(self) -> Optional[str]:
+        return self.params.get("macaroon")
+
+    @property
+    def token(self) -> Optional[str]:
+        return self.params.get("token") or self.params.get("access_token")
+
+    @property
+    def cache_key(self) -> Optional[str]:
+        """Return a deterministic cache key for the challenge."""
+
+        if self.realm:
+            return self.realm
+        if self.token:
+            return f"token:{self.token}"
+        if self.invoice:
+            return f"invoice:{self.invoice}"
+        return None
+
+    @classmethod
+    def from_header(cls, header_value: Optional[str]) -> Optional["X402Challenge"]:
+        """Parse a ``WWW-Authenticate`` header and return the X402 challenge, if any."""
+        if not header_value:
+            return None
+
+        header_value = header_value.strip()
+        if not header_value:
+            return None
+
+        fragments = _extract_challenges(header_value)
+        index = 0
+        while index < len(fragments):
+            fragment = fragments[index].strip()
+            index += 1
+            if not fragment:
+                continue
+            scheme, _, param_str = fragment.partition(" ")
+            if scheme.lower() != "x-402":
+                continue
+
+            # Accumulate any trailing parameter fragments that belong to the
+            # current challenge. Some servers emit ``scheme key=value, key2=value``.
+            assembled = fragment
+            while index < len(fragments) and _looks_like_parameter(fragments[index]):
+                assembled = f"{assembled}, {fragments[index].strip()}"
+                index += 1
+
+            _, _, param_str = assembled.partition(" ")
+            params = _parse_params(param_str)
+            return cls(scheme=scheme, params=params, raw=assembled)
+        return None
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return f"X402Challenge(scheme={self.scheme!r}, params={self.params!r})"
+
+
+@runtime_checkable
+class X402PaymentProvider(Protocol):
+    """Protocol for components capable of resolving X402 challenges."""
+
+    def obtain_authorization(self, challenge: X402Challenge) -> X402Authorization:
+        """Return valid credentials for the provided challenge."""
+
+
+class StaticX402PaymentProvider:
+    """Simple provider that always returns the same credentials."""
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        macaroon: Optional[str] = None,
+        preimage: Optional[str] = None,
+        scheme: str = "X-402",
+    ):
+        if not token and not preimage:
+            raise ValueError("token or preimage must be provided")
+        self._authorization = X402Authorization(
+            token=token,
+            macaroon=macaroon,
+            preimage=preimage,
+            scheme=scheme,
+        )
+
+    def obtain_authorization(self, challenge: X402Challenge) -> X402Authorization:  # noqa: D401 - short delegation
+        """Return the configured authorization regardless of the challenge."""
+
+        del challenge
+        return self._authorization
+
+
+class X402Client:
+    """HTTP client capable of automatically resolving X402 challenges."""
+
+    def __init__(
+        self,
+        payment_provider: X402PaymentProvider,
+        *,
+        session: Optional[requests.Session] = None,
+        max_challenge_attempts: int = 4,
+        token_cache: Optional[MutableMapping[str, X402Authorization]] = None,
+        clock: Optional[Callable[[], _dt.datetime]] = None,
+    ) -> None:
+        if not isinstance(payment_provider, X402PaymentProvider):
+            raise TypeError("payment_provider must implement X402PaymentProvider")
+        if max_challenge_attempts < 1:
+            raise ValueError("max_challenge_attempts must be >= 1")
+
+        self._payment_provider = payment_provider
+        self._session = session or requests.Session()
+        self._max_attempts = max_challenge_attempts
+        self._token_cache: MutableMapping[str, X402Authorization] = token_cache or {}
+        self._host_cache: Dict[str, str] = {}
+        self._clock = clock or (lambda: _dt.datetime.now(tz=_dt.timezone.utc))
+
+    @property
+    def session(self) -> requests.Session:
+        return self._session
+
+    def clear_cache(self) -> None:
+        """Remove all cached authorizations."""
+
+        self._token_cache.clear()
+        self._host_cache.clear()
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        **kwargs,
+    ) -> requests.Response:
+        """Perform an HTTP request handling X402 challenges transparently."""
+
+        attempts = 0
+        host = urlparse(url).netloc
+        cached_key = self._host_cache.get(host)
+        cached_auth = self._get_cached_authorization(cached_key)
+        resolved_keys: Set[str] = set()
+
+        while attempts < self._max_attempts:
+            attempts += 1
+            now = self._clock()
+            request_headers = dict(headers or {})
+
+            if (
+                cached_auth
+                and not cached_auth.is_expired(now=now)
+                and "Authorization" not in request_headers
+            ):
+                request_headers["Authorization"] = cached_auth.as_header()
+
+            logger.debug(
+                "X402 request attempt %s %s (Authorization=%s)",
+                attempts,
+                url,
+                request_headers.get("Authorization"),
+            )
+            response = self._session.request(
+                method,
+                url,
+                headers=request_headers,
+                **kwargs,
+            )
+
+            if response.status_code != 402:
+                if response.status_code in (401, 403) and cached_key:
+                    if cached_auth is not None:
+                        self._evict_cached_authorization(cached_key)
+                        cached_auth = None
+                    resolved_keys.discard(cached_key)
+                    if attempts < self._max_attempts:
+                        continue
+                return response
+
+            challenge = X402Challenge.from_header(response.headers.get("WWW-Authenticate"))
+            if challenge is None:
+                logger.debug("No X402 challenge present in response headers")
+                raise X402AuthenticationError("Received 402 response without X-402 challenge")
+
+            cache_key = challenge.cache_key or host
+            self._host_cache[host] = cache_key
+            cached_key = cache_key
+
+            cached_auth = self._get_cached_authorization(cache_key)
+            if cached_auth and cached_auth.is_expired(now=now):
+                self._evict_cached_authorization(cache_key)
+                cached_auth = None
+
+            if cached_auth is not None:
+                # We already have valid credentials for this challenge; retry with them.
+                continue
+
+            if cache_key in resolved_keys:
+                raise X402AuthenticationError(
+                    "Challenge could not be satisfied after obtaining credentials"
+                )
+            resolved_keys.add(cache_key)
+
+            cached_auth = self._resolve_challenge(challenge)
+            if cached_auth.is_expired(now=now):
+                raise X402AuthenticationError(
+                    "Received immediately expired X402 authorization from provider"
+                )
+            self._token_cache[cache_key] = cached_auth
+
+        raise X402AuthenticationError("Exceeded maximum number of X402 challenge attempts")
+
+    def _resolve_challenge(self, challenge: X402Challenge) -> X402Authorization:
+        try:
+            authorization = self._payment_provider.obtain_authorization(challenge)
+        except Exception as exc:  # pragma: no cover - defensive programming
+            logger.exception("Failed to resolve X402 challenge: %s", exc)
+            raise X402AuthenticationError(str(exc)) from exc
+
+        if not isinstance(authorization, X402Authorization):
+            raise X402AuthenticationError(
+                "Payment provider did not return an X402Authorization instance"
+            )
+        return authorization
+
+    def _get_cached_authorization(
+        self, cache_key: Optional[str]
+    ) -> Optional[X402Authorization]:
+        if cache_key is None:
+            return None
+        authorization = self._token_cache.get(cache_key)
+        if authorization is None:
+            return None
+        return authorization
+
+    def _evict_cached_authorization(self, cache_key: str) -> None:
+        self._token_cache.pop(cache_key, None)
+        stale_hosts = [host for host, key in self._host_cache.items() if key == cache_key]
+        for host in stale_hosts:
+            self._host_cache.pop(host, None)
+
+
+_PARAM_PATTERN = re.compile(r"(?P<key>[^=\s]+)\s*=\s*(?P<value>\"[^\"]*\"|[^,]+)")
+
+
+def _extract_challenges(header_value: str) -> list[str]:
+    """Split a ``WWW-Authenticate`` header into individual challenges."""
+
+    parts: list[str] = []
+    current = []
+    in_quotes = False
+    for char in header_value:
+        if char == '"':
+            in_quotes = not in_quotes
+        if char == ',' and not in_quotes:
+            part = ''.join(current).strip()
+            if part:
+                parts.append(part)
+            current = []
+            continue
+        current.append(char)
+    final = ''.join(current).strip()
+    if final:
+        parts.append(final)
+    return parts
+
+
+def _parse_params(param_str: str) -> Dict[str, str]:
+    params: Dict[str, str] = {}
+    for match in _PARAM_PATTERN.finditer(param_str):
+        key = match.group("key")
+        value = match.group("value").strip()
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        params[key] = value
+    return params
+
+
+def _looks_like_parameter(fragment: str) -> bool:
+    fragment = fragment.strip()
+    if not fragment or "=" not in fragment:
+        return False
+    key, _ = fragment.split("=", 1)
+    return " " not in key
+
+
+def _quote(value: str) -> str:
+    return '"' + value.replace('"', '\\"') + '"'

--- a/tests/test_x402_client.py
+++ b/tests/test_x402_client.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict
+from unittest.mock import MagicMock
+
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:  # pragma: no cover - defensive path setup
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+try:  # pragma: no cover - optional dependency shim for CI environments
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback when requests is unavailable
+    from types import ModuleType
+
+    class _Response:  # Minimal stub mimicking requests.Response for testing
+        def __init__(self) -> None:
+            self.status_code = 200
+            self.headers: Dict[str, str] = {}
+            self._content: bytes = b""
+            self.url = ""
+
+        def json(self):
+            raise ValueError("JSON not available in stub response")
+
+        @property
+        def text(self) -> str:
+            return self._content.decode()
+
+    class _Session:  # Minimal stub used only for typing in mocks
+        def request(self, *args, **kwargs):  # pragma: no cover - stub method
+            raise NotImplementedError
+
+    requests = ModuleType("requests")
+    requests.Response = _Response
+    requests.Session = _Session
+    sys.modules.setdefault("requests", requests)
+
+from spoon_ai.x402.client import (
+    StaticX402PaymentProvider,
+    X402Authorization,
+    X402Challenge,
+    X402Client,
+)
+
+
+def _build_response(status_code: int, headers: Dict[str, str] | None = None, body: bytes = b"") -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response.headers.update(headers or {})
+    response._content = body
+    response.url = "https://example.com"
+    return response
+
+
+def test_challenge_parsing_extracts_values() -> None:
+    header = 'Basic realm="ignored", X-402 realm="restricted", invoice="bolt11", macaroon="mac", token="abc"'
+    challenge = X402Challenge.from_header(header)
+    assert challenge is not None
+    assert challenge.realm == "restricted"
+    assert challenge.invoice == "bolt11"
+    assert challenge.macaroon == "mac"
+    assert challenge.token == "abc"
+    assert challenge.cache_key == "restricted"
+
+
+def test_challenge_cache_key_falls_back_to_invoice() -> None:
+    challenge = X402Challenge.from_header('X-402 invoice="bolt11"')
+    assert challenge is not None
+    assert challenge.cache_key == "invoice:bolt11"
+
+
+def test_authorization_header_serialization() -> None:
+    auth = X402Authorization(token="token", macaroon="mac", preimage="pre")
+    header = auth.as_header()
+    assert header.startswith("X-402 ")
+    assert 'access_token="token"' in header
+    assert 'macaroon="mac"' in header
+    assert 'preimage="pre"' in header
+
+
+class _CountingProvider:
+    def __init__(self, authorization: X402Authorization | None = None):
+        self.calls = 0
+        self.authorization = authorization or X402Authorization(token="token-value")
+        self.last_challenge: X402Challenge | None = None
+
+    def obtain_authorization(self, challenge: X402Challenge) -> X402Authorization:
+        self.calls += 1
+        self.last_challenge = challenge
+        return self.authorization
+
+
+def test_client_retries_request_with_authorization() -> None:
+    provider = _CountingProvider()
+    session = MagicMock(spec=requests.Session)
+    session.request.side_effect = [
+        _build_response(
+            402,
+            headers={"WWW-Authenticate": 'X-402 realm="restricted", invoice="bolt11"'},
+        ),
+        _build_response(200, body=b"ok"),
+    ]
+
+    client = X402Client(provider, session=session)
+    response = client.request("GET", "https://example.com")
+
+    assert response.status_code == 200
+    assert provider.calls == 1
+    assert session.request.call_count == 2
+    # The second call should include the Authorization header
+    _, second_kwargs = session.request.call_args
+    assert "Authorization" in second_kwargs["headers"]
+
+
+def test_cached_authorization_reused() -> None:
+    provider = _CountingProvider()
+    session = MagicMock(spec=requests.Session)
+    session.request.side_effect = [
+        _build_response(
+            402,
+            headers={"WWW-Authenticate": 'X-402 realm="restricted"'},
+        ),
+        _build_response(200, body=b"first"),
+        _build_response(200, body=b"second"),
+    ]
+
+    client = X402Client(provider, session=session)
+    assert client.request("GET", "https://example.com").text == "first"
+    assert client.request("GET", "https://example.com").text == "second"
+    assert provider.calls == 1
+
+
+def test_authorization_expiry_evicts_cache() -> None:
+    provider = StaticX402PaymentProvider(token="abc")
+    session = MagicMock(spec=requests.Session)
+    expired_auth = X402Authorization(
+        token="stale",
+        expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    client = X402Client(
+        provider,
+        session=session,
+        token_cache={"restricted": expired_auth},
+    )
+
+    session.request.side_effect = [
+        _build_response(402, headers={"WWW-Authenticate": 'X-402 realm="restricted"'}),
+        _build_response(200, body=b"ok"),
+    ]
+
+    response = client.request("GET", "https://example.com")
+    assert response.status_code == 200
+    assert session.request.call_count == 2
+
+
+def test_client_evicts_cache_on_403() -> None:
+    provider = _CountingProvider()
+    session = MagicMock(spec=requests.Session)
+    session.request.side_effect = [
+        _build_response(
+            402,
+            headers={"WWW-Authenticate": 'X-402 realm="restricted"'},
+        ),
+        _build_response(403),
+        _build_response(
+            402,
+            headers={"WWW-Authenticate": 'X-402 realm="restricted"'},
+        ),
+        _build_response(200, body=b"ok"),
+    ]
+
+    client = X402Client(provider, session=session)
+    response = client.request("GET", "https://example.com")
+
+    assert response.status_code == 200
+    assert provider.calls == 2
+    assert session.request.call_count == 4
+
+
+def test_missing_challenge_raises() -> None:
+    provider = _CountingProvider()
+    session = MagicMock(spec=requests.Session)
+    session.request.side_effect = [
+        _build_response(402, headers={}),
+    ]
+
+    client = X402Client(provider, session=session)
+
+    try:
+        client.request("GET", "https://example.com")
+    except RuntimeError as exc:
+        assert "X-402" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected an error when no challenge is present")
+
+
+def test_provider_exception_wrapped() -> None:
+    class _FailingProvider(_CountingProvider):
+        def obtain_authorization(self, challenge: X402Challenge) -> X402Authorization:
+            raise RuntimeError("boom")
+
+    provider = _FailingProvider()
+    session = MagicMock(spec=requests.Session)
+    session.request.side_effect = [
+        _build_response(
+            402,
+            headers={"WWW-Authenticate": 'X-402 realm="restricted"'},
+        ),
+    ]
+
+    client = X402Client(provider, session=session)
+
+    try:
+        client.request("GET", "https://example.com")
+    except RuntimeError as exc:
+        assert "boom" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected provider failure to propagate")


### PR DESCRIPTION
## Summary
- extend the X402 authorization and challenge parsing logic to capture macaroon/preimage fields and deterministic cache keys
- harden the X402 client retry loop with host-scoped caching, 401/403 eviction, and validation of provider responses
- expand unit coverage for parsing edge cases, cache eviction, error propagation, and header serialization

## Testing
- pytest tests/test_x402_client.py

------
https://chatgpt.com/codex/tasks/task_e_68fcb8b4c35883328537d0bb89508dcd