### PR TITLE
fix: preserve final summaries after streamed thinking and tool execution

### DIFF
--- a/spoon_ai/agents/toolcall.py
+++ b/spoon_ai/agents/toolcall.py
@@ -22,6 +22,12 @@ logging.getLogger("spoon_ai").setLevel(logging.INFO)
 
 logger = getLogger("spoon_ai")
 
+FINAL_RESPONSE_PROMPT = (
+    "You have reached the tool budget. Do not call any more tools. "
+    "Using only the tool results already in memory, provide the final user-facing answer now. "
+    "Summarize the concrete results and do not describe future actions."
+)
+
 class ToolCallAgent(ReActAgent):
 
     name: str = "toolcall"
@@ -407,6 +413,9 @@ class ToolCallAgent(ReActAgent):
                 logger.info(f"Step {self.current_step}: {step_result}")
 
             if self.current_step >= self.max_steps:
+                final_content = await self._maybe_finalize_after_tool_budget()
+                if final_content:
+                    return final_content
                 results.append(f"Step {self.current_step}: Stuck in loop. Resetting state.")
 
             if self._middleware_pipeline:
@@ -616,6 +625,37 @@ class ToolCallAgent(ReActAgent):
         err = getattr(self, "last_tool_error", None)
         self.last_tool_error = None
         return err
+
+    async def _maybe_finalize_after_tool_budget(self) -> str:
+        """Allow one final, tool-free summary turn after the last tool step."""
+        last_message = self.memory.messages[-1] if self.memory.messages else None
+        if getattr(last_message, "role", None) != "tool":
+            return ""
+
+        original_tool_choices = self.tool_choices
+        original_tool_calls = list(self.tool_calls)
+        original_next_step_prompt = self.next_step_prompt
+        try:
+            self.tool_calls = []
+            self.next_step_prompt = FINAL_RESPONSE_PROMPT
+            await self.add_message("user", FINAL_RESPONSE_PROMPT)
+
+            final_content = await self.llm.ask(
+                messages=self.memory.messages,
+                system_msg=self.system_prompt,
+            )
+            final_content = (final_content or "").strip()
+            if not final_content:
+                return ""
+
+            await self.add_message("assistant", final_content)
+            if self.output_queue:
+                self.output_queue.put_nowait({"content": final_content})
+            return final_content
+        finally:
+            self.tool_choices = original_tool_choices
+            self.tool_calls = original_tool_calls
+            self.next_step_prompt = original_next_step_prompt
 
 
     def _handle_special_tool(self, name: str, result:Any, **kwargs):

--- a/spoon_ai/agents/toolcall.py
+++ b/spoon_ai/agents/toolcall.py
@@ -241,7 +241,7 @@ class ToolCallAgent(ReActAgent):
             if response.content and not streamed_content:
                 self.output_queue.put_nowait(
                     build_output_queue_event(
-                        event_type="content",
+                        event_type="thinking",
                         delta=response.content,
                         metadata={
                             "phase": "think",

--- a/spoon_ai/llm/providers/anthropic_provider.py
+++ b/spoon_ai/llm/providers/anthropic_provider.py
@@ -609,7 +609,6 @@ class AnthropicProvider(LLMProviderInterface):
                                             event_type="content",
                                             delta=chunk.delta.text,
                                             metadata={
-                                                "phase": "think",
                                                 "provider": "anthropic",
                                                 "channel": "text",
                                             },

--- a/spoon_ai/llm/providers/openai_compatible_provider.py
+++ b/spoon_ai/llm/providers/openai_compatible_provider.py
@@ -986,7 +986,6 @@ class OpenAICompatibleProvider(LLMProviderInterface):
                                     event_type="content",
                                     delta=token,
                                     metadata={
-                                        "phase": "think",
                                         "provider": self.get_provider_name(),
                                         "channel": "text",
                                     },

--- a/tests/test_agent_llm_integration.py
+++ b/tests/test_agent_llm_integration.py
@@ -239,7 +239,7 @@ class TestAgentLLMIntegration:
         assert all(call.args != ({"content": "already streamed full text"},) for call in put_calls)
 
     @pytest.mark.asyncio
-    async def test_toolcall_agent_labels_non_streamed_pre_tool_content_with_think_phase(self, mock_chatbot_manager, tool_manager):
+    async def test_toolcall_agent_emits_explicit_thinking_for_non_streamed_pre_tool_content(self, mock_chatbot_manager, tool_manager):
         mock_tool_call = ToolCall(
             id="call_123",
             type="function",
@@ -272,7 +272,7 @@ class TestAgentLLMIntegration:
         assert should_continue is True
         put_calls = mock_queue.put_nowait.call_args_list
         assert put_calls[0].args[0] == {
-            "type": "content",
+            "type": "thinking",
             "delta": "First I will inspect the workspace.",
             "content": "First I will inspect the workspace.",
             "metadata": {

--- a/tests/test_agent_llm_integration.py
+++ b/tests/test_agent_llm_integration.py
@@ -281,6 +281,53 @@ class TestAgentLLMIntegration:
             },
         }
         assert put_calls[1].args[0] == {"tool_calls": [mock_tool_call]}
+
+    @pytest.mark.asyncio
+    async def test_toolcall_agent_uses_final_tool_free_summary_after_budget_exhaustion(self, mock_chatbot_manager, tool_manager):
+        mock_tool_call = ToolCall(
+            id="call_123",
+            type="function",
+            function=Function(
+                name="test_tool",
+                arguments='{"param":"value"}',
+            ),
+        )
+        mock_chatbot_manager.ask_tool.side_effect = [
+            ManagerLLMResponse(
+                content="First I will use a tool.",
+                provider="openai",
+                model="gpt-4.1",
+                finish_reason="tool_calls",
+                native_finish_reason="tool_calls",
+                tool_calls=[mock_tool_call],
+                metadata={"streamed_content": False},
+            ),
+            ManagerLLMResponse(
+                content="Final summary after tool execution.",
+                provider="openai",
+                model="gpt-4.1",
+                finish_reason="stop",
+                native_finish_reason="stop",
+                tool_calls=[],
+            ),
+        ]
+        mock_chatbot_manager.ask.return_value = "Final summary after tool execution."
+
+        tool_manager.execute = AsyncMock(return_value="Tool executed successfully")
+        tool_manager.tool_map = {"test_tool": Mock()}
+
+        agent = ToolCallAgent(
+            name="streaming_agent",
+            llm=mock_chatbot_manager,
+            available_tools=tool_manager,
+            max_steps=1,
+        )
+
+        result = await agent.run("Use a tool and summarize")
+
+        assert result == "Final summary after tool execution."
+        assert mock_chatbot_manager.ask_tool.await_count == 1
+        mock_chatbot_manager.ask.assert_awaited_once()
     
     @pytest.mark.asyncio
     async def test_agent_memory_consistency(self, mock_chatbot_manager, tool_manager):

--- a/tests/test_tool_streaming_output.py
+++ b/tests/test_tool_streaming_output.py
@@ -142,7 +142,8 @@ async def test_openai_chat_with_tools_streams_deltas_to_output_queue():
 
     assert [chunk["content"] for chunk in chunks] == ["Hel", "lo"]
     assert all(chunk["type"] == "content" for chunk in chunks)
-    assert all(chunk["metadata"]["phase"] == "think" for chunk in chunks)
+    assert all(chunk["metadata"]["channel"] == "text" for chunk in chunks)
+    assert all("phase" not in chunk["metadata"] for chunk in chunks)
     assert response.content == "Hello"
     assert response.metadata.get("streamed_content") is True
 
@@ -242,7 +243,8 @@ async def test_anthropic_chat_with_tools_streams_deltas_to_output_queue():
 
     assert [chunk["content"] for chunk in deltas] == ["Hel", "lo"]
     assert all(chunk["type"] == "content" for chunk in deltas)
-    assert all(chunk["metadata"]["phase"] == "think" for chunk in deltas)
+    assert all(chunk["metadata"]["channel"] == "text" for chunk in deltas)
+    assert all("phase" not in chunk["metadata"] for chunk in deltas)
     assert response.content == "Hello"
     assert response.finish_reason == "stop"
     assert response.native_finish_reason == "end_turn"


### PR DESCRIPTION
## Summary
- preserve pre-tool streamed narration as `thinking` without leaking it into final content buffers
- add a final tool-free summary turn in `ToolCallAgent` when the tool budget is exhausted right after the last tool result
- cover the non-streamed thinking path and the budget-exhaustion final-summary path with regression tests

## Problem
WS/REST streaming could reach a state where:
- TUI-like pre-tool planning text was emitted before tool calls
- the final `agent.complete.response` fell back to concatenated intermediate content, or degraded to a generic completion string, if no dedicated post-tool summary turn remained

## Fix
- keep final answer generation separate from pre-tool thinking buffers
- when the last memory entry is a tool result and `max_steps` is exhausted, force one extra tool-free final answer turn using existing memory only
- persist that final answer into the output queue so `stream.done` and `agent.complete` stay aligned

## Verification
- `python -m pytest tests/test_agent_llm_integration.py -q -k "emits_explicit_thinking_for_non_streamed_pre_tool_content or final_tool_free_summary_after_budget_exhaustion"`
