### PR TITLE
Fix tool response turn ordering for Gemini and OpenAI-compatible providers

### DIFF
--- a/spoon_ai/llm/providers/gemini_provider.py
+++ b/spoon_ai/llm/providers/gemini_provider.py
@@ -517,17 +517,25 @@ class GeminiProvider(LLMProviderInterface):
         """
         system_content = ""
         gemini_messages = []
+        normalized_messages = self._normalize_tool_message_sequence(messages)
+        index = 0
 
-        for message in messages:
+        while index < len(normalized_messages):
+            message = normalized_messages[index]
             if message.role == "system":
                 msg_text = message.text_content if message.is_multimodal else message.content
                 if system_content:
                     system_content += " " + msg_text
                 else:
                     system_content = msg_text or ""
+                index += 1
             elif message.role == "user":
-                # Handle both text and multimodal user messages
-                parts = self._convert_message_content_to_parts(message.content)
+                parts = []
+                while index < len(normalized_messages) and normalized_messages[index].role == "user":
+                    parts.extend(
+                        self._convert_message_content_to_parts(normalized_messages[index].content)
+                    )
+                    index += 1
                 gemini_messages.append(types.Content(
                     role="user",
                     parts=parts
@@ -555,36 +563,92 @@ class GeminiProvider(LLMProviderInterface):
                         role="model",
                         parts=[types.Part.from_text(text=message.content)]
                     ))
+                index += 1
             elif message.role == "tool":
-                # Convert tool response to Gemini format
-                # Gemini requires a non-empty name for function_response
-                tool_name = message.name
-                if not tool_name:
-                    # Fallback: try to extract tool name from tool_call_id or use a default
-                    if message.tool_call_id:
-                        # Try to find the corresponding tool call in previous messages
-                        for prev_msg in reversed(messages):
-                            if prev_msg.role == "assistant" and prev_msg.tool_calls:
-                                for tool_call in prev_msg.tool_calls:
-                                    if tool_call.id == message.tool_call_id:
-                                        tool_name = tool_call.function.name
-                                        break
-                                if tool_name:
-                                    break
-
-                    # If still no name found, use a default
-                    if not tool_name:
-                        tool_name = "unknown_function"
-
+                parts = []
+                while index < len(normalized_messages) and normalized_messages[index].role == "tool":
+                    tool_message = normalized_messages[index]
+                    tool_name = self._resolve_tool_response_name(normalized_messages, tool_message)
+                    parts.append(
+                        types.Part.from_function_response(
+                            name=tool_name,
+                            response={"result": tool_message.content}
+                        )
+                    )
+                    index += 1
                 gemini_messages.append(types.Content(
                     role="user",
-                    parts=[types.Part.from_function_response(
-                        name=tool_name,
-                        response={"result": message.content}
-                    )]
+                    parts=parts
                 ))
+            else:
+                index += 1
 
         return system_content, gemini_messages
+
+    @staticmethod
+    def _normalize_tool_message_sequence(messages: List[Message]) -> List[Message]:
+        """Reorder tool responses to immediately follow the issuing assistant turn."""
+        if not messages:
+            return messages
+
+        claimed_tool_indices: set[int] = set()
+        tool_messages_by_assistant_index: Dict[int, List[Message]] = {}
+
+        for index, message in enumerate(messages):
+            if message.role != "tool" or not getattr(message, "tool_call_id", None):
+                continue
+
+            for candidate_index in range(index - 1, -1, -1):
+                candidate = messages[candidate_index]
+                if candidate.role != "assistant" or not candidate.tool_calls:
+                    continue
+
+                if any(tool_call.id == message.tool_call_id for tool_call in candidate.tool_calls):
+                    tool_messages_by_assistant_index.setdefault(candidate_index, []).append(message)
+                    claimed_tool_indices.add(index)
+                    break
+
+        if not claimed_tool_indices:
+            return messages
+
+        normalized_messages: List[Message] = []
+        for index, message in enumerate(messages):
+            if index in claimed_tool_indices:
+                continue
+
+            normalized_messages.append(message)
+            if message.role != "assistant" or not message.tool_calls:
+                continue
+
+            tool_order = {
+                tool_call.id: position
+                for position, tool_call in enumerate(message.tool_calls)
+            }
+            matched_tool_messages = tool_messages_by_assistant_index.get(index, [])
+            matched_tool_messages.sort(
+                key=lambda item: tool_order.get(item.tool_call_id, len(tool_order))
+            )
+            normalized_messages.extend(matched_tool_messages)
+
+        return normalized_messages
+
+    @staticmethod
+    def _resolve_tool_response_name(messages: List[Message], message: Message) -> str:
+        """Resolve the function name for a Gemini function_response turn."""
+        tool_name = message.name
+        if tool_name:
+            return tool_name
+
+        tool_call_id = getattr(message, "tool_call_id", None)
+        if tool_call_id:
+            for previous_message in reversed(messages):
+                if previous_message.role != "assistant" or not previous_message.tool_calls:
+                    continue
+                for tool_call in previous_message.tool_calls:
+                    if tool_call.id == tool_call_id:
+                        return tool_call.function.name
+
+        return "unknown_function"
 
     def _sanitize_gemini_schema(self, schema: Dict[str, Any]) -> Dict[str, Any]:
         """Remove fields that are not supported by Gemini function declarations."""

--- a/spoon_ai/llm/providers/openai_compatible_provider.py
+++ b/spoon_ai/llm/providers/openai_compatible_provider.py
@@ -502,11 +502,69 @@ class OpenAICompatibleProvider(LLMProviderInterface):
 
         return self._validate_and_fix_message_sequence(openai_messages)
 
+    @staticmethod
+    def _reorder_tool_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Move tool results to immediately follow the assistant tool-call turn.
+
+        Some runtimes inject extra user guidance turns between the assistant
+        tool-call message and its tool responses. OpenAI-compatible APIs accept
+        only the adjacent sequence assistant(tool_calls) -> tool results.
+        """
+        if not messages:
+            return messages
+
+        claimed_tool_indices: set[int] = set()
+        tool_messages_by_assistant_index: Dict[int, List[Dict[str, Any]]] = {}
+
+        for index, message in enumerate(messages):
+            if message.get("role") != "tool":
+                continue
+
+            tool_call_id = message.get("tool_call_id")
+            if not tool_call_id:
+                continue
+
+            for candidate_index in range(index - 1, -1, -1):
+                candidate = messages[candidate_index]
+                if candidate.get("role") != "assistant":
+                    continue
+
+                tool_calls = candidate.get("tool_calls") or []
+                if any(tool_call.get("id") == tool_call_id for tool_call in tool_calls):
+                    tool_messages_by_assistant_index.setdefault(candidate_index, []).append(message)
+                    claimed_tool_indices.add(index)
+                    break
+
+        if not claimed_tool_indices:
+            return messages
+
+        reordered_messages: List[Dict[str, Any]] = []
+        for index, message in enumerate(messages):
+            if index in claimed_tool_indices:
+                continue
+
+            reordered_messages.append(message)
+            if message.get("role") != "assistant" or not message.get("tool_calls"):
+                continue
+
+            tool_order = {
+                tool_call.get("id"): position
+                for position, tool_call in enumerate(message.get("tool_calls", []))
+            }
+            matched_tool_messages = tool_messages_by_assistant_index.get(index, [])
+            matched_tool_messages.sort(
+                key=lambda item: tool_order.get(item.get("tool_call_id"), len(tool_order))
+            )
+            reordered_messages.extend(matched_tool_messages)
+
+        return reordered_messages
+
     def _validate_and_fix_message_sequence(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Validate and fix message sequence to comply with OpenAI API requirements."""
         if not messages:
             return messages
 
+        messages = self._reorder_tool_messages(messages)
         fixed_messages = []
         i = 0
 

--- a/tests/test_provider_message_sequence.py
+++ b/tests/test_provider_message_sequence.py
@@ -1,0 +1,84 @@
+"""Provider-level regressions for tool-call message ordering."""
+
+from spoon_ai.llm.providers.gemini_provider import GeminiProvider
+from spoon_ai.llm.providers.openai_compatible_provider import OpenAICompatibleProvider
+from spoon_ai.schema import Function, Message, ToolCall
+
+
+def _tool_call(tool_call_id: str, name: str, arguments: str) -> ToolCall:
+    return ToolCall(
+        id=tool_call_id,
+        type="function",
+        function=Function(name=name, arguments=arguments),
+    )
+
+
+def test_openai_validator_moves_tool_result_immediately_after_assistant_tool_call():
+    provider = OpenAICompatibleProvider()
+
+    messages = [
+        {"role": "user", "content": "Inspect the workspace."},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_shell",
+                    "type": "function",
+                    "function": {
+                        "name": "shell",
+                        "arguments": "{\"command\":\"pwd\"}",
+                    },
+                }
+            ],
+        },
+        {"role": "user", "content": "Focus on the current request."},
+        {
+            "role": "tool",
+            "tool_call_id": "call_shell",
+            "name": "shell",
+            "content": "/workspace",
+        },
+    ]
+
+    fixed = provider._validate_and_fix_message_sequence(messages)
+
+    assert [message["role"] for message in fixed] == ["user", "assistant", "tool", "user"]
+    assert fixed[2]["tool_call_id"] == "call_shell"
+    assert fixed[3]["content"] == "Focus on the current request."
+
+
+def test_gemini_converter_merges_adjacent_user_turns_and_groups_tool_results():
+    provider = GeminiProvider()
+
+    messages = [
+        Message(role="user", content="Inspect the workspace."),
+        Message(role="user", content="Focus on the active request."),
+        Message(
+            role="assistant",
+            content="",
+            tool_calls=[
+                _tool_call("call_read", "read_file", '{"path":"README.md"}'),
+                _tool_call("call_shell", "shell", '{"command":"pwd"}'),
+            ],
+        ),
+        Message(role="tool", content="/workspace", tool_call_id="call_shell", name="shell"),
+        Message(role="tool", content="[file output]", tool_call_id="call_read", name="read_file"),
+    ]
+
+    system_content, gemini_messages = provider._convert_messages_for_tools(messages)
+
+    assert system_content == ""
+    assert [message.role for message in gemini_messages] == ["user", "model", "user"]
+
+    first_user_parts = gemini_messages[0].parts
+    assert [part.text for part in first_user_parts] == [
+        "Inspect the workspace.",
+        "Focus on the active request.",
+    ]
+
+    model_parts = gemini_messages[1].parts
+    assert [part.function_call.name for part in model_parts] == ["read_file", "shell"]
+
+    tool_parts = gemini_messages[2].parts
+    assert [part.function_response.name for part in tool_parts] == ["read_file", "shell"]


### PR DESCRIPTION
## Summary
- reorder misplaced tool responses so they immediately follow the assistant tool-call turn for OpenAI-compatible providers
- normalize Gemini tool-call history before conversion, merge adjacent user turns, and group consecutive tool responses into a single Gemini function-response turn
- add provider-level regression coverage for tool turn ordering and Gemini tool response grouping

## Testing
- C:\Users\Ricky\Documents\Project\XSpoonAi\spoon-bot-function-response-turn-order\.venv\Scripts\python.exe -m pytest tests/test_provider_message_sequence.py -q
- C:\Users\Ricky\Documents\Project\XSpoonAi\spoon-bot-function-response-turn-order\.venv\Scripts\python.exe -m pytest tests/test_tool_streaming_output.py -q

## Notes
- companion spoon-bot runtime guard branch: `fix/gemini-function-response-turn-order`