### PR TITLE
fix: stream OpenRouter reasoning when thinking is enabled

### DIFF
--- a/spoon_ai/agents/spoon_react.py
+++ b/spoon_ai/agents/spoon_react.py
@@ -200,5 +200,6 @@ class SpoonReactAI(MCPClientMixin, ToolCallAgent):
             kwargs["request"] = request
         if timeout is not None:
             kwargs["timeout"] = timeout
-        kwargs["thinking"] = thinking
+        if thinking:
+            kwargs["thinking"] = True
         return await super().run(**kwargs)

--- a/spoon_ai/agents/spoon_react.py
+++ b/spoon_ai/agents/spoon_react.py
@@ -187,7 +187,12 @@ class SpoonReactAI(MCPClientMixin, ToolCallAgent):
 
         self._x402_tools_initialized = True
 
-    async def run(self, request: Optional[str] = None, timeout: Optional[float] = None) -> str:
+    async def run(
+        self,
+        request: Optional[str] = None,
+        timeout: Optional[float] = None,
+        thinking: bool = False,
+    ) -> str:
         """Ensure prompts reflect current tools before running."""
         self._refresh_prompts()
         kwargs: dict = {}
@@ -195,4 +200,5 @@ class SpoonReactAI(MCPClientMixin, ToolCallAgent):
             kwargs["request"] = request
         if timeout is not None:
             kwargs["timeout"] = timeout
+        kwargs["thinking"] = thinking
         return await super().run(**kwargs)

--- a/spoon_ai/agents/spoon_react_skill.py
+++ b/spoon_ai/agents/spoon_react_skill.py
@@ -89,7 +89,12 @@ class SpoonReactSkill(SkillEnabledMixin, SpoonReactAI):
 
         self._skill_manager_initialized = True
 
-    async def run(self, request: Optional[str] = None, timeout: Optional[float] = None) -> str:
+    async def run(
+        self,
+        request: Optional[str] = None,
+        timeout: Optional[float] = None,
+        thinking: bool = False,
+    ) -> str:
         """
         Execute agent with per-turn auto skill activation.
 
@@ -115,6 +120,7 @@ class SpoonReactSkill(SkillEnabledMixin, SpoonReactAI):
                 kwargs["request"] = req
             if timeout is not None:
                 kwargs["timeout"] = timeout
+            kwargs["thinking"] = thinking
             return await super(SpoonReactSkill, self).run(**kwargs)
 
         return await self._run_with_auto_skills(request, _runner)

--- a/spoon_ai/agents/spoon_react_skill.py
+++ b/spoon_ai/agents/spoon_react_skill.py
@@ -120,7 +120,8 @@ class SpoonReactSkill(SkillEnabledMixin, SpoonReactAI):
                 kwargs["request"] = req
             if timeout is not None:
                 kwargs["timeout"] = timeout
-            kwargs["thinking"] = thinking
+            if thinking:
+                kwargs["thinking"] = True
             return await super(SpoonReactSkill, self).run(**kwargs)
 
         return await self._run_with_auto_skills(request, _runner)

--- a/spoon_ai/agents/toolcall.py
+++ b/spoon_ai/agents/toolcall.py
@@ -199,15 +199,17 @@ class ToolCallAgent(ReActAgent):
                 )
             else:
                 # Fallback: direct LLM call without middleware
+                ask_tool_kwargs = {
+                    "messages": self.memory.messages,
+                    "system_msg": self.system_prompt,
+                    "tools": unique_tools_list,
+                    "tool_choice": self.tool_choices,
+                    "output_queue": self.output_queue,
+                }
+                if thinking:
+                    ask_tool_kwargs["thinking"] = True
                 response = await asyncio.wait_for(
-                    self.llm.ask_tool(
-                        messages=self.memory.messages,
-                        system_msg=self.system_prompt,
-                        tools=unique_tools_list,
-                        tool_choice=self.tool_choices,
-                        output_queue=self.output_queue,
-                        thinking=thinking,
-                    ),
+                    self.llm.ask_tool(**ask_tool_kwargs),
                     timeout=llm_timeout,
                 )
         except asyncio.TimeoutError:

--- a/spoon_ai/agents/toolcall.py
+++ b/spoon_ai/agents/toolcall.py
@@ -117,7 +117,7 @@ class ToolCallAgent(ReActAgent):
 
 
 
-    async def think(self) -> bool:
+    async def think(self, thinking: bool = False) -> bool:
         if self.next_step_prompt:
             await self.add_message("user", self.next_step_prompt)
 
@@ -194,7 +194,8 @@ class ToolCallAgent(ReActAgent):
             if hasattr(self, '_middleware_pipeline') and self._middleware_pipeline:
                 response = await self._call_llm_with_middleware(
                     unique_tools_list,
-                    llm_timeout
+                    llm_timeout,
+                    thinking=thinking,
                 )
             else:
                 # Fallback: direct LLM call without middleware
@@ -205,6 +206,7 @@ class ToolCallAgent(ReActAgent):
                         tools=unique_tools_list,
                         tool_choice=self.tool_choices,
                         output_queue=self.output_queue,
+                        thinking=thinking,
                     ),
                     timeout=llm_timeout,
                 )
@@ -280,7 +282,12 @@ class ToolCallAgent(ReActAgent):
             await self.add_message("assistant", f"Error encountered while thinking: {e}")
             return False
 
-    async def run(self, request: Optional[str] = None, timeout: Optional[float] = None) -> str:
+    async def run(
+        self,
+        request: Optional[str] = None,
+        timeout: Optional[float] = None,
+        thinking: bool = False,
+    ) -> str:
         """
 
         This ensures:
@@ -383,7 +390,10 @@ class ToolCallAgent(ReActAgent):
                                 logger.info(f"Subagent detected: step_timeout={step_timeout}s")
                                 break
 
-                    step_result = await asyncio.wait_for(self.step(), timeout=step_timeout)
+                    step_result = await asyncio.wait_for(
+                        self.step(thinking=thinking),
+                        timeout=step_timeout,
+                    )
                     if await self.is_stuck():
                         await self.handle_stuck_state()
                 except asyncio.TimeoutError:
@@ -449,9 +459,9 @@ class ToolCallAgent(ReActAgent):
                 self.state = AgentState.IDLE
                 self.current_step = 0
 
-    async def step(self) -> str:
+    async def step(self, thinking: bool = False) -> str:
         """Override the step method to handle finish_reason termination properly."""
-        should_act = await self.think()
+        should_act = await self.think(thinking=thinking)
         if not should_act:
             if self.state == AgentState.FINISHED:
                 # For finish_reason termination, return a simple message
@@ -684,7 +694,13 @@ class ToolCallAgent(ReActAgent):
             return native_finish_reason in ["stop", "end_turn"]
         return False
 
-    async def _call_llm_with_middleware(self, tools: list, timeout: float):
+    async def _call_llm_with_middleware(
+        self,
+        tools: list,
+        timeout: float,
+        *,
+        thinking: bool = False,
+    ):
         """Call LLM through middleware pipeline for observability.
 
         """
@@ -707,7 +723,8 @@ class ToolCallAgent(ReActAgent):
             tools=tools,
             tool_choice=tool_choice,
             runtime=runtime,
-            phase=AgentPhase.THINK
+            phase=AgentPhase.THINK,
+            extra_params={"thinking": thinking} if thinking else {},
         )
 
         # Define base handler that calls the actual LLM
@@ -720,6 +737,7 @@ class ToolCallAgent(ReActAgent):
                     tools=req.tools,
                     tool_choice=req.tool_choice,
                     output_queue=self.output_queue,
+                    **req.extra_params,
                 ),
                 timeout=timeout,
             )

--- a/spoon_ai/agents/toolcall.py
+++ b/spoon_ai/agents/toolcall.py
@@ -118,7 +118,8 @@ class ToolCallAgent(ReActAgent):
 
 
     async def think(self, thinking: bool = False) -> bool:
-        if self.next_step_prompt:
+        last_role = getattr(self.memory.messages[-1], "role", None) if self.memory.messages else None
+        if self.next_step_prompt and last_role != "user":
             await self.add_message("user", self.next_step_prompt)
 
         # Use cached MCP tools to avoid repeated server calls

--- a/spoon_ai/chat.py
+++ b/spoon_ai/chat.py
@@ -656,6 +656,37 @@ class ChatBot:
         except Exception as exc:
             logger.warning("Failed to store interaction in Mem0: %s", exc)
 
+    def _normalize_tool_request_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Convert high-level thinking toggles into provider-specific tool kwargs."""
+        normalized = dict(kwargs)
+        if "thinking" not in normalized:
+            return normalized
+
+        thinking = normalized.get("thinking")
+        if not thinking:
+            normalized.pop("thinking", None)
+            return normalized
+
+        provider = (self.llm_provider or "").strip().lower()
+        if provider == "anthropic":
+            if isinstance(thinking, dict):
+                thinking_config = dict(thinking)
+                if thinking_config.get("type") != "disabled":
+                    thinking_config.setdefault("type", "enabled")
+                    thinking_config.setdefault("budget_tokens", 1024)
+                normalized["thinking"] = thinking_config
+            else:
+                normalized["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": 1024,
+                }
+        elif provider == "gemini":
+            normalized.pop("thinking", None)
+            if "thinking_config" not in normalized and "thinking_budget" not in normalized:
+                normalized["thinking_budget"] = 32
+
+        return normalized
+
     async def ask(self, messages: List[Union[dict, Message]], system_msg: Optional[str] = None, output_queue: Optional[asyncio.Queue] = None) -> str:
         """Ask method using the LLM manager architecture.
         
@@ -688,6 +719,7 @@ class ChatBot:
             messages_with_long_term,
             model=self.model_name,
         )
+        request_kwargs = self._normalize_tool_request_kwargs(kwargs)
 
         response = await self.llm_manager.chat_with_tools(
             messages=processed_messages,
@@ -695,7 +727,7 @@ class ChatBot:
             provider=self.llm_provider,
             tool_choice=tool_choice,
             output_queue=output_queue,
-            **kwargs
+            **request_kwargs
         )
 
         await self._store_long_term_memory(user_query, response.content)

--- a/spoon_ai/llm/providers/anthropic_provider.py
+++ b/spoon_ai/llm/providers/anthropic_provider.py
@@ -341,6 +341,22 @@ class AnthropicProvider(LLMProviderInterface):
     def get_cache_metrics(self) -> Dict[str, int]:
         """Get current cache performance metrics."""
         return self.cache_metrics.copy()
+
+    @staticmethod
+    def _normalize_thinking_param(thinking: Any) -> Optional[Dict[str, Any]]:
+        """Accept a boolean alias but send Anthropic the structured thinking object."""
+        if isinstance(thinking, dict):
+            normalized = dict(thinking)
+            if normalized.get("type") != "disabled":
+                normalized.setdefault("type", "enabled")
+                normalized.setdefault("budget_tokens", 1024)
+            return normalized
+        if thinking is True:
+            return {
+                "type": "enabled",
+                "budget_tokens": 1024,
+            }
+        return None
     
     async def chat(self, messages: List[Message], **kwargs) -> LLMResponse:
         """Send chat request to Anthropic."""
@@ -363,13 +379,22 @@ class AnthropicProvider(LLMProviderInterface):
                 model = self.model or "claude-sonnet-4-20250514"
             
             # Prepare request parameters
+            extra_request_kwargs = {
+                k: v for k, v in kwargs.items() if k not in ['model', 'max_tokens', 'temperature']
+            }
+            thinking_config = self._normalize_thinking_param(
+                extra_request_kwargs.pop("thinking", None)
+            )
+
             request_params = {
                 'model': model,
                 'max_tokens': max_tokens,
                 'temperature': temperature,
                 'messages': anthropic_messages,
-                **{k: v for k, v in kwargs.items() if k not in ['model', 'max_tokens', 'temperature']}
+                **extra_request_kwargs,
             }
+            if thinking_config is not None:
+                request_params['thinking'] = thinking_config
             
             # Only add system parameter if we have system content
             if system_content is not None:
@@ -417,14 +442,23 @@ class AnthropicProvider(LLMProviderInterface):
             )
             
             # Prepare request parameters
+            extra_request_kwargs = {
+                k: v for k, v in kwargs.items()
+                if k not in ['model', 'max_tokens', 'temperature', 'callbacks']
+            }
+            thinking_config = self._normalize_thinking_param(
+                extra_request_kwargs.pop("thinking", None)
+            )
+
             request_params = {
                 'model': model,
                 'max_tokens': max_tokens,
                 'temperature': temperature,
                 'messages': anthropic_messages,
-                **{k: v for k, v in kwargs.items() 
-                   if k not in ['model', 'max_tokens', 'temperature', 'callbacks']}
+                **extra_request_kwargs,
             }
+            if thinking_config is not None:
+                request_params['thinking'] = thinking_config
             
             # Only add system parameter if we have system content
             if system_content is not None:
@@ -547,14 +581,24 @@ class AnthropicProvider(LLMProviderInterface):
             emitted_chunk_count = 0
 
             # Prepare request parameters
+            extra_request_kwargs = {
+                k: v for k, v in kwargs.items()
+                if k not in ['model', 'max_tokens', 'temperature', 'tool_choice', 'output_queue']
+            }
+            thinking_config = self._normalize_thinking_param(
+                extra_request_kwargs.pop("thinking", None)
+            )
+
             request_params = {
                 'model': model,
                 'max_tokens': max_tokens,
                 'temperature': temperature,
                 'messages': anthropic_messages,
                 'tools': anthropic_tools,
-                **{k: v for k, v in kwargs.items() if k not in ['model', 'max_tokens', 'temperature', 'tool_choice', 'output_queue']}
+                **extra_request_kwargs,
             }
+            if thinking_config is not None:
+                request_params['thinking'] = thinking_config
 
             # Anthropic expects tool_choice as an object, not a plain string/enum
             if tool_choice:

--- a/spoon_ai/llm/providers/openai_compatible_provider.py
+++ b/spoon_ai/llm/providers/openai_compatible_provider.py
@@ -147,6 +147,71 @@ class OpenAICompatibleProvider(LLMProviderInterface):
         """Get the default model. Should be overridden by subclasses."""
         return self.default_model
 
+    def _is_openrouter_request(self) -> bool:
+        """Detect whether the current request targets OpenRouter semantics."""
+        provider_name = (self.get_provider_name() or "").lower()
+        if provider_name == "openrouter":
+            return True
+
+        base_url = (self.config.get("base_url") or self.get_default_base_url() or "").lower()
+        return "openrouter.ai" in base_url
+
+    def _apply_reasoning_defaults(
+        self,
+        request_kwargs: Dict[str, Any],
+        overrides: Dict[str, Any],
+    ) -> None:
+        """Enable low-effort reasoning for OpenRouter when thinking is requested."""
+        if not overrides.get("thinking") or not self._is_openrouter_request():
+            return
+
+        if request_kwargs.get("reasoning") is not None:
+            return
+
+        extra_body = request_kwargs.get("extra_body")
+        if extra_body is not None and not isinstance(extra_body, dict):
+            return
+        if isinstance(extra_body, dict) and extra_body.get("reasoning") is not None:
+            return
+
+        merged_extra_body = dict(extra_body or {})
+        merged_extra_body["reasoning"] = {"effort": "low"}
+        request_kwargs["extra_body"] = merged_extra_body
+
+    @staticmethod
+    def _extract_reasoning_text(
+        *,
+        reasoning: Any = None,
+        reasoning_content: Any = None,
+        reasoning_details: Any = None,
+    ) -> str:
+        """Extract plaintext reasoning while avoiding duplicate fields."""
+        primary = reasoning if reasoning is not None else reasoning_content
+        if isinstance(primary, str) and primary:
+            return primary
+
+        texts: List[str] = []
+        seen: set[str] = set()
+        details = reasoning_details or []
+        for detail in details:
+            if isinstance(detail, dict):
+                detail_type = detail.get("type")
+                text = detail.get("text")
+            else:
+                detail_type = getattr(detail, "type", None)
+                text = getattr(detail, "text", None)
+
+            if not text or detail_type != "reasoning.text":
+                continue
+
+            text = str(text)
+            if text in seen:
+                continue
+            seen.add(text)
+            texts.append(text)
+
+        return "".join(texts)
+
     def get_additional_headers(self, config: Dict[str, Any]) -> Dict[str, str]:
         """Get additional headers for the provider. Can be overridden by subclasses."""
         return {}
@@ -644,6 +709,11 @@ class OpenAICompatibleProvider(LLMProviderInterface):
         """Convert OpenAI-compatible response to standardized LLMResponse."""
         choice = response.choices[0]
         message = choice.message
+        reasoning_text = self._extract_reasoning_text(
+            reasoning=getattr(message, "reasoning", None),
+            reasoning_content=getattr(message, "reasoning_content", None),
+            reasoning_details=getattr(message, "reasoning_details", None),
+        )
 
         # Convert tool calls
         tool_calls = []
@@ -686,6 +756,14 @@ class OpenAICompatibleProvider(LLMProviderInterface):
                 "total_tokens": response.usage.total_tokens
             }
 
+        metadata = {
+            "response_id": response.id,
+            "created": response.created,
+            "system_fingerprint": getattr(response, 'system_fingerprint', None)
+        }
+        if reasoning_text:
+            metadata["reasoning"] = reasoning_text
+
         return LLMResponse(
             content=message.content or "",
             provider=self.get_provider_name(),
@@ -695,11 +773,7 @@ class OpenAICompatibleProvider(LLMProviderInterface):
             tool_calls=tool_calls,
             usage=usage,
             duration=duration,
-            metadata={
-                "response_id": response.id,
-                "created": response.created,
-                "system_fingerprint": getattr(response, 'system_fingerprint', None)
-            }
+            metadata=metadata
         )
 
     async def chat(self, messages: List[Message], **kwargs) -> LLMResponse:
@@ -738,8 +812,9 @@ class OpenAICompatibleProvider(LLMProviderInterface):
                 request_kwargs["tools"] = tools
                 request_kwargs["tool_choice"] = tool_choice
 
-            extra_keys = {'model', 'max_tokens', 'max_completion_tokens', 'temperature', 'tools', 'tool_choice'}
+            extra_keys = {'model', 'max_tokens', 'max_completion_tokens', 'temperature', 'thinking', 'tools', 'tool_choice'}
             request_kwargs.update({k: v for k, v in kwargs.items() if k not in extra_keys})
+            self._apply_reasoning_defaults(request_kwargs, kwargs)
 
             response = await self.client.chat.completions.create(**request_kwargs)
 
@@ -797,8 +872,9 @@ class OpenAICompatibleProvider(LLMProviderInterface):
                 request_kwargs["tools"] = tools
                 request_kwargs["tool_choice"] = tool_choice
 
-            extra_keys = {'model', 'max_tokens', 'max_completion_tokens', 'temperature', 'callbacks', 'tools', 'tool_choice'}
+            extra_keys = {'model', 'max_tokens', 'max_completion_tokens', 'temperature', 'thinking', 'callbacks', 'tools', 'tool_choice'}
             request_kwargs.update({k: v for k, v in kwargs.items() if k not in extra_keys})
+            self._apply_reasoning_defaults(request_kwargs, kwargs)
 
             stream = await self.client.chat.completions.create(**request_kwargs)
             # Process streaming response
@@ -1007,8 +1083,9 @@ class OpenAICompatibleProvider(LLMProviderInterface):
                 request_kwargs["tools"] = tools
                 request_kwargs["tool_choice"] = tool_choice
 
-            extra_keys = {'model', 'max_tokens', 'max_completion_tokens', 'temperature', 'tool_choice', 'output_queue'}
+            extra_keys = {'model', 'max_tokens', 'max_completion_tokens', 'temperature', 'thinking', 'tool_choice', 'output_queue'}
             request_kwargs.update({k: v for k, v in kwargs.items() if k not in extra_keys})
+            self._apply_reasoning_defaults(request_kwargs, kwargs)
 
             if output_queue is not None:
                 request_kwargs["stream"] = True
@@ -1034,6 +1111,26 @@ class OpenAICompatibleProvider(LLMProviderInterface):
 
                     choice = chunk.choices[0]
                     delta = choice.delta
+                    reasoning_token = self._extract_reasoning_text(
+                        reasoning=getattr(delta, "reasoning", None),
+                        reasoning_content=getattr(delta, "reasoning_content", None),
+                        reasoning_details=getattr(delta, "reasoning_details", None),
+                    )
+                    if reasoning_token:
+                        try:
+                            output_queue.put_nowait(
+                                build_output_queue_event(
+                                    event_type="thinking",
+                                    delta=reasoning_token,
+                                    metadata={
+                                        "phase": "think",
+                                        "provider": self.get_provider_name(),
+                                        "channel": "thinking",
+                                    },
+                                )
+                            )
+                        except Exception:
+                            pass
                     token = delta.content or ""
                     if token:
                         full_content += token

--- a/tests/test_agent_llm_integration.py
+++ b/tests/test_agent_llm_integration.py
@@ -2,11 +2,13 @@
 Integration tests for agents with the new LLM architecture.
 """
 
+import inspect
 import pytest
 import asyncio
 from unittest.mock import Mock, AsyncMock, patch
 from spoon_ai.agents.toolcall import ToolCallAgent
 from spoon_ai.agents.spoon_react import SpoonReactAI
+from spoon_ai.agents.spoon_react_skill import SpoonReactSkill
 from spoon_ai.chat import ChatBot
 from spoon_ai.schema import Message, LLMResponse, ToolCall, Function, AgentState
 from spoon_ai.llm.interface import LLMResponse as ManagerLLMResponse
@@ -64,6 +66,25 @@ class TestAgentLLMIntegration:
         # Verify agent used the ChatBot
         mock_chatbot_manager.ask_tool.assert_called()
         assert "I'll help you with that task." in result
+
+    @pytest.mark.asyncio
+    async def test_toolcall_agent_forwards_thinking_flag_to_llm(self, mock_chatbot_manager, tool_manager):
+        mock_chatbot_manager.ask_tool.return_value = LLMResponse(
+            content="I'll help you with that task.",
+            tool_calls=[],
+            finish_reason="stop",
+            native_finish_reason="stop",
+        )
+
+        agent = ToolCallAgent(
+            name="test_agent",
+            llm=mock_chatbot_manager,
+            available_tools=tool_manager,
+        )
+
+        await agent.run("Test request", thinking=True)
+
+        assert mock_chatbot_manager.ask_tool.await_args.kwargs["thinking"] is True
     
     @pytest.mark.asyncio
     async def test_toolcall_agent_with_tools(self, mock_chatbot_manager, tool_manager):
@@ -120,6 +141,10 @@ class TestAgentLLMIntegration:
             
             # Verify it uses the new architecture
             assert agent.llm.use_llm_manager is True
+
+    def test_spoon_react_run_signatures_accept_thinking(self):
+        assert "thinking" in inspect.signature(SpoonReactAI.run).parameters
+        assert "thinking" in inspect.signature(SpoonReactSkill.run).parameters
     
     @pytest.mark.asyncio
     async def test_spoon_react_ai_fallback_to_legacy(self):

--- a/tests/test_agent_llm_integration.py
+++ b/tests/test_agent_llm_integration.py
@@ -85,6 +85,25 @@ class TestAgentLLMIntegration:
         await agent.run("Test request", thinking=True)
 
         assert mock_chatbot_manager.ask_tool.await_args.kwargs["thinking"] is True
+
+    @pytest.mark.asyncio
+    async def test_toolcall_agent_omits_disabled_thinking_flag_for_llm(self, mock_chatbot_manager, tool_manager):
+        mock_chatbot_manager.ask_tool.return_value = LLMResponse(
+            content="I'll help you with that task.",
+            tool_calls=[],
+            finish_reason="stop",
+            native_finish_reason="stop",
+        )
+
+        agent = ToolCallAgent(
+            name="test_agent",
+            llm=mock_chatbot_manager,
+            available_tools=tool_manager,
+        )
+
+        await agent.run("Test request")
+
+        assert "thinking" not in mock_chatbot_manager.ask_tool.await_args.kwargs
     
     @pytest.mark.asyncio
     async def test_toolcall_agent_with_tools(self, mock_chatbot_manager, tool_manager):

--- a/tests/test_agent_llm_integration.py
+++ b/tests/test_agent_llm_integration.py
@@ -104,6 +104,31 @@ class TestAgentLLMIntegration:
         await agent.run("Test request")
 
         assert "thinking" not in mock_chatbot_manager.ask_tool.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_toolcall_agent_does_not_append_next_step_prompt_after_user_message(self, mock_chatbot_manager, tool_manager):
+        mock_chatbot_manager.ask_tool.return_value = LLMResponse(
+            content="I'll help you with that task.",
+            tool_calls=[],
+            finish_reason="stop",
+            native_finish_reason="stop",
+        )
+
+        agent = ToolCallAgent(
+            name="test_agent",
+            llm=mock_chatbot_manager,
+            available_tools=tool_manager,
+            next_step_prompt="Think step-by-step before choosing tools.",
+        )
+        await agent.add_message("user", "Test request")
+
+        await agent.think(thinking=True)
+
+        messages = mock_chatbot_manager.ask_tool.await_args.kwargs["messages"]
+        user_messages = [msg for msg in messages if getattr(msg, "role", None) == "user"]
+
+        assert len(user_messages) == 1
+        assert getattr(user_messages[0], "content", None) == "Test request"
     
     @pytest.mark.asyncio
     async def test_toolcall_agent_with_tools(self, mock_chatbot_manager, tool_manager):

--- a/tests/test_tool_streaming_output.py
+++ b/tests/test_tool_streaming_output.py
@@ -110,6 +110,79 @@ async def test_chatbot_ask_tool_forwards_output_queue():
 
 
 @pytest.mark.asyncio
+async def test_chatbot_ask_tool_strips_disabled_thinking_flag():
+    mock_manager = SimpleNamespace(chat_with_tools=AsyncMock())
+    mock_manager.chat_with_tools.return_value = LLMResponse(
+        content="ok",
+        provider="anthropic",
+        model="claude-sonnet-4-20250514",
+        finish_reason="stop",
+        native_finish_reason="stop",
+    )
+
+    with patch("spoon_ai.chat.get_llm_manager", return_value=mock_manager):
+        bot = ChatBot(use_llm_manager=True, llm_provider="anthropic")
+        await bot.ask_tool(
+            [{"role": "user", "content": "hi"}],
+            tools=_tool_spec(),
+            thinking=False,
+        )
+
+    call = mock_manager.chat_with_tools.call_args
+    assert "thinking" not in call.kwargs
+
+
+@pytest.mark.asyncio
+async def test_chatbot_ask_tool_normalizes_anthropic_boolean_thinking():
+    mock_manager = SimpleNamespace(chat_with_tools=AsyncMock())
+    mock_manager.chat_with_tools.return_value = LLMResponse(
+        content="ok",
+        provider="anthropic",
+        model="claude-sonnet-4-20250514",
+        finish_reason="stop",
+        native_finish_reason="stop",
+    )
+
+    with patch("spoon_ai.chat.get_llm_manager", return_value=mock_manager):
+        bot = ChatBot(use_llm_manager=True, llm_provider="anthropic")
+        await bot.ask_tool(
+            [{"role": "user", "content": "hi"}],
+            tools=_tool_spec(),
+            thinking=True,
+        )
+
+    call = mock_manager.chat_with_tools.call_args
+    assert call.kwargs["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": 1024,
+    }
+
+
+@pytest.mark.asyncio
+async def test_chatbot_ask_tool_normalizes_gemini_boolean_thinking():
+    mock_manager = SimpleNamespace(chat_with_tools=AsyncMock())
+    mock_manager.chat_with_tools.return_value = LLMResponse(
+        content="ok",
+        provider="gemini",
+        model="gemini-3-flash-preview",
+        finish_reason="stop",
+        native_finish_reason="stop",
+    )
+
+    with patch("spoon_ai.chat.get_llm_manager", return_value=mock_manager):
+        bot = ChatBot(use_llm_manager=True, llm_provider="gemini")
+        await bot.ask_tool(
+            [{"role": "user", "content": "hi"}],
+            tools=_tool_spec(),
+            thinking=True,
+        )
+
+    call = mock_manager.chat_with_tools.call_args
+    assert "thinking" not in call.kwargs
+    assert call.kwargs["thinking_budget"] == 32
+
+
+@pytest.mark.asyncio
 async def test_openai_chat_with_tools_streams_deltas_to_output_queue():
     provider = OpenAICompatibleProvider()
     provider.model = "gpt-4.1"
@@ -385,6 +458,41 @@ async def test_anthropic_chat_with_tools_streams_provider_thinking_to_output_que
     ]
     assert response.finish_reason == "tool_calls"
     assert response.tool_calls[0].function.arguments == '{"command":"pwd"}'
+
+
+@pytest.mark.asyncio
+async def test_anthropic_chat_with_tools_normalizes_boolean_thinking_before_request():
+    provider = AnthropicProvider()
+    provider.model = "claude-sonnet-4-20250514"
+
+    captured_kwargs: dict = {}
+    chunks = [
+        SimpleNamespace(type="content_block_start", content_block=SimpleNamespace(type="text")),
+        SimpleNamespace(type="content_block_delta", delta=SimpleNamespace(type="text_delta", text="ok")),
+        SimpleNamespace(type="content_block_stop"),
+        SimpleNamespace(type="message_delta", delta=SimpleNamespace(stop_reason="end_turn")),
+        SimpleNamespace(type="message_stop", message=SimpleNamespace(stop_reason="end_turn")),
+    ]
+
+    def _stream(**request_kwargs):
+        captured_kwargs.update(request_kwargs)
+        return _AsyncStreamContext(chunks)
+
+    provider.client = SimpleNamespace(
+        messages=SimpleNamespace(stream=_stream)
+    )
+
+    response = await provider.chat_with_tools(
+        messages=[Message(role="user", content="hi")],
+        tools=_tool_spec(),
+        thinking=True,
+    )
+
+    assert captured_kwargs["thinking"] == {
+        "type": "enabled",
+        "budget_tokens": 1024,
+    }
+    assert response.content == "ok"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_streaming_output.py
+++ b/tests/test_tool_streaming_output.py
@@ -16,6 +16,7 @@ from spoon_ai.llm.providers.anthropic_provider import AnthropicProvider
 from spoon_ai.llm.providers.gemini_provider import GeminiProvider
 from spoon_ai.llm.providers.ollama_provider import OllamaProvider
 from spoon_ai.llm.providers.openai_compatible_provider import OpenAICompatibleProvider
+from spoon_ai.llm.providers.openrouter_provider import OpenRouterProvider
 
 
 class _AsyncItems:
@@ -145,6 +146,95 @@ async def test_openai_chat_with_tools_streams_deltas_to_output_queue():
     assert all(chunk["metadata"]["channel"] == "text" for chunk in chunks)
     assert all("phase" not in chunk["metadata"] for chunk in chunks)
     assert response.content == "Hello"
+    assert response.metadata.get("streamed_content") is True
+
+
+@pytest.mark.asyncio
+async def test_openrouter_chat_with_tools_streams_reasoning_to_output_queue():
+    provider = OpenRouterProvider()
+    provider.model = "google/gemini-3-flash-preview"
+
+    create_mock = AsyncMock()
+    stream_items = [
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        content="",
+                        reasoning="Plan: inspect files first.",
+                        reasoning_content=None,
+                        reasoning_details=[
+                            SimpleNamespace(
+                                type="reasoning.text",
+                                text="Plan: inspect files first.",
+                            )
+                        ],
+                        tool_calls=None,
+                    ),
+                    finish_reason=None,
+                )
+            ],
+            usage=None,
+        ),
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    delta=SimpleNamespace(
+                        content="Done.",
+                        reasoning=None,
+                        reasoning_content=None,
+                        reasoning_details=None,
+                        tool_calls=None,
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=None,
+        ),
+    ]
+    create_mock.return_value = _AsyncItems(stream_items)
+    provider.client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=create_mock),
+        )
+    )
+
+    q: asyncio.Queue = asyncio.Queue()
+    response = await provider.chat_with_tools(
+        messages=[Message(role="user", content="hi")],
+        tools=_tool_spec(),
+        output_queue=q,
+        thinking=True,
+    )
+
+    streamed_events: list[dict] = []
+    while not q.empty():
+        streamed_events.append(await q.get())
+
+    assert streamed_events == [
+        {
+            "type": "thinking",
+            "delta": "Plan: inspect files first.",
+            "content": "Plan: inspect files first.",
+            "metadata": {
+                "phase": "think",
+                "provider": "openrouter",
+                "channel": "thinking",
+            },
+        },
+        {
+            "type": "content",
+            "delta": "Done.",
+            "content": "Done.",
+            "metadata": {
+                "provider": "openrouter",
+                "channel": "text",
+            },
+        },
+    ]
+    assert create_mock.call_args.kwargs["extra_body"]["reasoning"] == {"effort": "low"}
+    assert "thinking" not in create_mock.call_args.kwargs
+    assert response.content == "Done."
     assert response.metadata.get("streamed_content") is True
 
 


### PR DESCRIPTION
## Summary
- pass the `thinking` flag through `ToolCallAgent`, `SpoonReactAI`, and `SpoonReactSkillAgent`
- inject OpenRouter/OpenAI-compatible reasoning config when `thinking=True`
- surface streamed reasoning deltas as `thinking` output-queue chunks and lock behavior with integration tests

## Testing
- `python -m pytest tests/test_tool_streaming_output.py::test_openai_chat_with_tools_streams_deltas_to_output_queue tests/test_tool_streaming_output.py::test_openrouter_chat_with_tools_streams_reasoning_to_output_queue tests/test_agent_llm_integration.py::TestAgentLLMIntegration::test_toolcall_agent_forwards_thinking_flag_to_llm tests/test_agent_llm_integration.py::TestAgentLLMIntegration::test_spoon_react_run_signatures_accept_thinking -q`

## Notes
- this is the provider-layer piece of the end-to-end websocket reasoning stream fix
- local downstream runtime verification used this change together with the paired spoon-bot/cypher_api branches
