### PR TITLE
Support provider-specific reasoning effort mapping from a neutral core setting

### DIFF
--- a/spoon_ai/agents/toolcall.py
+++ b/spoon_ai/agents/toolcall.py
@@ -117,7 +117,11 @@ class ToolCallAgent(ReActAgent):
 
 
 
-    async def think(self, thinking: bool = False) -> bool:
+    async def think(
+        self,
+        thinking: bool = False,
+        reasoning_effort: Optional[str] = None,
+    ) -> bool:
         last_role = getattr(self.memory.messages[-1], "role", None) if self.memory.messages else None
         if self.next_step_prompt and last_role != "user":
             await self.add_message("user", self.next_step_prompt)
@@ -209,6 +213,8 @@ class ToolCallAgent(ReActAgent):
                 }
                 if thinking:
                     ask_tool_kwargs["thinking"] = True
+                if reasoning_effort:
+                    ask_tool_kwargs["reasoning_effort"] = reasoning_effort
                 response = await asyncio.wait_for(
                     self.llm.ask_tool(**ask_tool_kwargs),
                     timeout=llm_timeout,
@@ -290,6 +296,7 @@ class ToolCallAgent(ReActAgent):
         request: Optional[str] = None,
         timeout: Optional[float] = None,
         thinking: bool = False,
+        reasoning_effort: Optional[str] = None,
     ) -> str:
         """
 
@@ -394,7 +401,7 @@ class ToolCallAgent(ReActAgent):
                                 break
 
                     step_result = await asyncio.wait_for(
-                        self.step(thinking=thinking),
+                        self.step(thinking=thinking, reasoning_effort=reasoning_effort),
                         timeout=step_timeout,
                     )
                     if await self.is_stuck():
@@ -462,9 +469,16 @@ class ToolCallAgent(ReActAgent):
                 self.state = AgentState.IDLE
                 self.current_step = 0
 
-    async def step(self, thinking: bool = False) -> str:
+    async def step(
+        self,
+        thinking: bool = False,
+        reasoning_effort: Optional[str] = None,
+    ) -> str:
         """Override the step method to handle finish_reason termination properly."""
-        should_act = await self.think(thinking=thinking)
+        should_act = await self.think(
+            thinking=thinking,
+            reasoning_effort=reasoning_effort,
+        )
         if not should_act:
             if self.state == AgentState.FINISHED:
                 # For finish_reason termination, return a simple message

--- a/spoon_ai/chat.py
+++ b/spoon_ai/chat.py
@@ -656,34 +656,216 @@ class ChatBot:
         except Exception as exc:
             logger.warning("Failed to store interaction in Mem0: %s", exc)
 
+    @staticmethod
+    def _reasoning_effort_alias(value: Any) -> Optional[str]:
+        """Normalize user-facing effort aliases into provider-neutral values."""
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            return str(value)
+
+        normalized = value.strip().lower()
+        if not normalized:
+            return None
+
+        aliases = {
+            "off": "none",
+            "disabled": "none",
+            "basic": "low",
+            "standard": "medium",
+            "on": "medium",
+            "extended": "high",
+        }
+        return aliases.get(normalized, normalized)
+
+    @staticmethod
+    def _canonical_model_name(model: str) -> str:
+        normalized = (model or "").strip().lower().replace("_", "-").replace(".", "-")
+        return normalized.rsplit("/", 1)[-1]
+
+    @classmethod
+    def _anthropic_supports_effort(cls, model: str) -> bool:
+        canonical = cls._canonical_model_name(model)
+        return canonical.startswith(
+            (
+                "claude-mythos-preview",
+                "claude-opus-4-5",
+                "claude-opus-4-6",
+                "claude-opus-4-7",
+                "claude-sonnet-4-6",
+            )
+        )
+
+    @classmethod
+    def _anthropic_supports_adaptive_thinking(cls, model: str) -> bool:
+        canonical = cls._canonical_model_name(model)
+        return canonical.startswith(
+            (
+                "claude-mythos-preview",
+                "claude-opus-4-6",
+                "claude-opus-4-7",
+                "claude-sonnet-4-6",
+            )
+        )
+
+    @classmethod
+    def _anthropic_supports_xhigh_effort(cls, model: str) -> bool:
+        canonical = cls._canonical_model_name(model)
+        return canonical.startswith("claude-opus-4-7")
+
+    @classmethod
+    def _openai_supports_none_effort(cls, model: str) -> bool:
+        canonical = cls._canonical_model_name(model)
+        return canonical.startswith(("gpt-5-2", "gpt-5-4"))
+
+    @classmethod
+    def _openai_supports_xhigh_effort(cls, model: str) -> bool:
+        canonical = cls._canonical_model_name(model)
+        return canonical.startswith(("gpt-5-2", "gpt-5-4"))
+
+    @classmethod
+    def _normalize_openai_reasoning_effort(cls, value: Any, model: str) -> Optional[str]:
+        effort = cls._reasoning_effort_alias(value)
+        if effort is None:
+            return None
+
+        if effort == "max":
+            effort = "xhigh" if cls._openai_supports_xhigh_effort(model) else "high"
+        if effort == "none" and not cls._openai_supports_none_effort(model):
+            return "minimal"
+        if effort == "xhigh" and not cls._openai_supports_xhigh_effort(model):
+            return "high"
+        return effort
+
+    @classmethod
+    def _normalize_openrouter_reasoning_effort(cls, value: Any) -> Optional[str]:
+        effort = cls._reasoning_effort_alias(value)
+        if effort == "max":
+            return "xhigh"
+        return effort
+
+    @classmethod
+    def _normalize_anthropic_effort(cls, value: Any, model: str) -> Optional[str]:
+        effort = cls._reasoning_effort_alias(value)
+        if effort in {None, "none"}:
+            return None
+        if effort == "minimal":
+            return "low"
+        if effort == "xhigh":
+            if cls._anthropic_supports_xhigh_effort(model):
+                return "xhigh"
+            return "max" if cls._anthropic_supports_effort(model) else "high"
+        if effort == "max" and not cls._anthropic_supports_effort(model):
+            return "high"
+        return effort
+
+    @classmethod
+    def _normalize_gemini_reasoning_level(cls, value: Any) -> Optional[str]:
+        effort = cls._reasoning_effort_alias(value)
+        if effort is None:
+            return None
+
+        mapping = {
+            "none": "minimal",
+            "minimal": "minimal",
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "max": "high",
+            "xhigh": "high",
+        }
+        return mapping.get(effort, "medium")
+
+    @classmethod
+    def _gemini_reasoning_budget(cls, model: str, value: Any) -> Optional[int]:
+        level = cls._normalize_gemini_reasoning_level(value)
+        if level is None:
+            return None
+
+        normalized_model = (model or "").strip().lower()
+        if "gemini-2.5-pro" in normalized_model:
+            mapping = {
+                "minimal": 128,
+                "low": 512,
+                "medium": 2048,
+                "high": -1,
+            }
+            return mapping[level]
+
+        if "gemini-2.5" in normalized_model:
+            mapping = {
+                "minimal": 32,
+                "low": 128,
+                "medium": 512,
+                "high": -1,
+            }
+            return mapping[level]
+
+        return None
+
     def _normalize_tool_request_kwargs(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """Convert high-level thinking toggles into provider-specific tool kwargs."""
         normalized = dict(kwargs)
-        if "thinking" not in normalized:
-            return normalized
-
-        thinking = normalized.get("thinking")
-        if not thinking:
-            normalized.pop("thinking", None)
-            return normalized
-
         provider = (self.llm_provider or "").strip().lower()
+        model = str(normalized.get("model") or self.model_name or "")
+        thinking = normalized.get("thinking")
+        reasoning_effort = normalized.get("reasoning_effort")
+
+        if "thinking" in normalized and not thinking:
+            normalized.pop("thinking", None)
+            thinking = None
+
+        if thinking is None and reasoning_effort is None:
+            return normalized
+
         if provider == "anthropic":
-            if isinstance(thinking, dict):
-                thinking_config = dict(thinking)
-                if thinking_config.get("type") != "disabled":
-                    thinking_config.setdefault("type", "enabled")
-                    thinking_config.setdefault("budget_tokens", 1024)
-                normalized["thinking"] = thinking_config
-            else:
-                normalized["thinking"] = {
-                    "type": "enabled",
-                    "budget_tokens": 1024,
-                }
+            anthropic_effort = self._normalize_anthropic_effort(reasoning_effort, model)
+            if anthropic_effort and self._anthropic_supports_effort(model):
+                output_config = dict(normalized.get("output_config") or {})
+                output_config["effort"] = anthropic_effort
+                normalized["output_config"] = output_config
+
+            if thinking:
+                if isinstance(thinking, dict):
+                    thinking_config = dict(thinking)
+                    thinking_type = str(thinking_config.get("type") or "").strip().lower()
+                    if thinking_type == "adaptive":
+                        normalized["thinking"] = {"type": "adaptive"}
+                    elif thinking_type != "disabled":
+                        thinking_config.setdefault("type", "enabled")
+                        thinking_config.setdefault("budget_tokens", 1024)
+                        normalized["thinking"] = thinking_config
+                elif anthropic_effort and self._anthropic_supports_adaptive_thinking(model):
+                    normalized["thinking"] = {"type": "adaptive"}
+                else:
+                    normalized["thinking"] = {
+                        "type": "enabled",
+                        "budget_tokens": 1024,
+                    }
+
         elif provider == "gemini":
             normalized.pop("thinking", None)
-            if "thinking_config" not in normalized and "thinking_budget" not in normalized:
+            if reasoning_effort is not None and "thinking_config" not in normalized and "thinking_budget" not in normalized:
+                if "gemini-3" in model.lower():
+                    normalized["thinking_config"] = {
+                        "thinking_level": self._normalize_gemini_reasoning_level(reasoning_effort),
+                    }
+                else:
+                    thinking_budget = self._gemini_reasoning_budget(model, reasoning_effort)
+                    if thinking_budget is not None:
+                        normalized["thinking_budget"] = thinking_budget
+            elif thinking and "thinking_config" not in normalized and "thinking_budget" not in normalized:
                 normalized["thinking_budget"] = 32
+
+        elif provider == "openai":
+            openai_effort = self._normalize_openai_reasoning_effort(reasoning_effort, model)
+            if openai_effort:
+                normalized["reasoning_effort"] = openai_effort
+
+        elif provider == "openrouter":
+            openrouter_effort = self._normalize_openrouter_reasoning_effort(reasoning_effort)
+            if openrouter_effort:
+                normalized["reasoning_effort"] = openrouter_effort
 
         return normalized
 
@@ -894,7 +1076,9 @@ class ChatBot:
         prepared_messages, all_callbacks = await self._prepare_run(
             messages, system_msg, callbacks
         )
-        stream_kwargs = sanitize_stream_kwargs(kwargs)
+        stream_kwargs = sanitize_stream_kwargs(
+            self._normalize_tool_request_kwargs(kwargs)
+        )
 
         async for chunk in self._stream_chat(
             prepared_messages, all_callbacks, stream_kwargs
@@ -985,7 +1169,9 @@ class ChatBot:
         processed_messages, all_callbacks = await self._prepare_run(
             messages, system_msg, callbacks
         )
-        stream_kwargs = sanitize_stream_kwargs(kwargs)
+        stream_kwargs = sanitize_stream_kwargs(
+            self._normalize_tool_request_kwargs(kwargs)
+        )
         
         # Chain start event
         yield StreamEventBuilder.chain_start(

--- a/spoon_ai/llm/providers/anthropic_provider.py
+++ b/spoon_ai/llm/providers/anthropic_provider.py
@@ -350,7 +350,10 @@ class AnthropicProvider(LLMProviderInterface):
         """Accept a boolean alias but send Anthropic the structured thinking object."""
         if isinstance(thinking, dict):
             normalized = dict(thinking)
-            if normalized.get("type") != "disabled":
+            thinking_type = str(normalized.get("type") or "").strip().lower()
+            if thinking_type == "adaptive":
+                return {"type": "adaptive"}
+            if thinking_type != "disabled":
                 normalized.setdefault("type", "enabled")
                 normalized.setdefault("budget_tokens", 1024)
             return normalized

--- a/spoon_ai/llm/providers/openai_compatible_provider.py
+++ b/spoon_ai/llm/providers/openai_compatible_provider.py
@@ -162,21 +162,28 @@ class OpenAICompatibleProvider(LLMProviderInterface):
         request_kwargs: Dict[str, Any],
         overrides: Dict[str, Any],
     ) -> None:
-        """Enable low-effort reasoning for OpenRouter when thinking is requested."""
-        if not overrides.get("thinking") or not self._is_openrouter_request():
+        """Normalize OpenRouter reasoning fields while preserving legacy thinking defaults."""
+        if not self._is_openrouter_request():
             return
 
-        if request_kwargs.get("reasoning") is not None:
-            return
+        requested_effort = request_kwargs.pop("reasoning_effort", None) or overrides.get("reasoning_effort")
 
         extra_body = request_kwargs.get("extra_body")
         if extra_body is not None and not isinstance(extra_body, dict):
             return
-        if isinstance(extra_body, dict) and extra_body.get("reasoning") is not None:
-            return
 
         merged_extra_body = dict(extra_body or {})
-        merged_extra_body["reasoning"] = {"effort": "low"}
+        reasoning_payload = dict(merged_extra_body.get("reasoning") or {})
+
+        if requested_effort:
+            reasoning_payload["effort"] = requested_effort
+        elif overrides.get("thinking") and not reasoning_payload:
+            reasoning_payload["effort"] = "low"
+
+        if not reasoning_payload:
+            return
+
+        merged_extra_body["reasoning"] = reasoning_payload
         request_kwargs["extra_body"] = merged_extra_body
 
     @staticmethod

--- a/tests/test_agent_llm_integration.py
+++ b/tests/test_agent_llm_integration.py
@@ -87,6 +87,26 @@ class TestAgentLLMIntegration:
         assert mock_chatbot_manager.ask_tool.await_args.kwargs["thinking"] is True
 
     @pytest.mark.asyncio
+    async def test_toolcall_agent_forwards_reasoning_effort_to_llm(self, mock_chatbot_manager, tool_manager):
+        mock_chatbot_manager.ask_tool.return_value = LLMResponse(
+            content="I'll help you with that task.",
+            tool_calls=[],
+            finish_reason="stop",
+            native_finish_reason="stop",
+        )
+
+        agent = ToolCallAgent(
+            name="test_agent",
+            llm=mock_chatbot_manager,
+            available_tools=tool_manager,
+        )
+
+        await agent.run("Test request", thinking=True, reasoning_effort="high")
+
+        assert mock_chatbot_manager.ask_tool.await_args.kwargs["thinking"] is True
+        assert mock_chatbot_manager.ask_tool.await_args.kwargs["reasoning_effort"] == "high"
+
+    @pytest.mark.asyncio
     async def test_toolcall_agent_omits_disabled_thinking_flag_for_llm(self, mock_chatbot_manager, tool_manager):
         mock_chatbot_manager.ask_tool.return_value = LLMResponse(
             content="I'll help you with that task.",

--- a/tests/test_tool_streaming_output.py
+++ b/tests/test_tool_streaming_output.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -159,6 +159,64 @@ async def test_chatbot_ask_tool_normalizes_anthropic_boolean_thinking():
 
 
 @pytest.mark.asyncio
+async def test_chatbot_ask_tool_normalizes_anthropic_reasoning_effort():
+    mock_manager = SimpleNamespace(chat_with_tools=AsyncMock())
+    mock_manager.chat_with_tools.return_value = LLMResponse(
+        content="ok",
+        provider="anthropic",
+        model="claude-sonnet-4.6",
+        finish_reason="stop",
+        native_finish_reason="stop",
+    )
+
+    with patch("spoon_ai.chat.get_llm_manager", return_value=mock_manager):
+        bot = ChatBot(
+            use_llm_manager=True,
+            llm_provider="anthropic",
+            model_name="claude-sonnet-4.6",
+        )
+        await bot.ask_tool(
+            [{"role": "user", "content": "hi"}],
+            tools=_tool_spec(),
+            thinking=True,
+            reasoning_effort="high",
+        )
+
+    call = mock_manager.chat_with_tools.call_args
+    assert call.kwargs["thinking"] == {"type": "adaptive"}
+    assert call.kwargs["output_config"] == {"effort": "high"}
+
+
+@pytest.mark.asyncio
+async def test_chatbot_ask_tool_maps_anthropic_xhigh_to_max_for_opus_46():
+    mock_manager = SimpleNamespace(chat_with_tools=AsyncMock())
+    mock_manager.chat_with_tools.return_value = LLMResponse(
+        content="ok",
+        provider="anthropic",
+        model="claude-opus-4.6",
+        finish_reason="stop",
+        native_finish_reason="stop",
+    )
+
+    with patch("spoon_ai.chat.get_llm_manager", return_value=mock_manager):
+        bot = ChatBot(
+            use_llm_manager=True,
+            llm_provider="anthropic",
+            model_name="anthropic/claude-opus-4.6",
+        )
+        await bot.ask_tool(
+            [{"role": "user", "content": "hi"}],
+            tools=_tool_spec(),
+            thinking=True,
+            reasoning_effort="xhigh",
+        )
+
+    call = mock_manager.chat_with_tools.call_args
+    assert call.kwargs["thinking"] == {"type": "adaptive"}
+    assert call.kwargs["output_config"] == {"effort": "max"}
+
+
+@pytest.mark.asyncio
 async def test_chatbot_ask_tool_normalizes_gemini_boolean_thinking():
     mock_manager = SimpleNamespace(chat_with_tools=AsyncMock())
     mock_manager.chat_with_tools.return_value = LLMResponse(
@@ -180,6 +238,84 @@ async def test_chatbot_ask_tool_normalizes_gemini_boolean_thinking():
     call = mock_manager.chat_with_tools.call_args
     assert "thinking" not in call.kwargs
     assert call.kwargs["thinking_budget"] == 32
+
+
+@pytest.mark.asyncio
+async def test_chatbot_ask_tool_normalizes_gemini_reasoning_effort():
+    mock_manager = SimpleNamespace(chat_with_tools=AsyncMock())
+    mock_manager.chat_with_tools.return_value = LLMResponse(
+        content="ok",
+        provider="gemini",
+        model="gemini-3-flash-preview",
+        finish_reason="stop",
+        native_finish_reason="stop",
+    )
+
+    with patch("spoon_ai.chat.get_llm_manager", return_value=mock_manager):
+        bot = ChatBot(
+            use_llm_manager=True,
+            llm_provider="gemini",
+            model_name="gemini-3-flash-preview",
+        )
+        await bot.ask_tool(
+            [{"role": "user", "content": "hi"}],
+            tools=_tool_spec(),
+            thinking=True,
+            reasoning_effort="high",
+        )
+
+    call = mock_manager.chat_with_tools.call_args
+    assert "thinking" not in call.kwargs
+    assert call.kwargs["thinking_config"] == {"thinking_level": "high"}
+
+
+@pytest.mark.asyncio
+async def test_chatbot_ask_tool_passes_openai_reasoning_effort_through():
+    mock_manager = SimpleNamespace(chat_with_tools=AsyncMock())
+    mock_manager.chat_with_tools.return_value = LLMResponse(
+        content="ok",
+        provider="openai",
+        model="gpt-5.2",
+        finish_reason="stop",
+        native_finish_reason="stop",
+    )
+
+    with patch("spoon_ai.chat.get_llm_manager", return_value=mock_manager):
+        bot = ChatBot(
+            use_llm_manager=True,
+            llm_provider="openai",
+            model_name="gpt-5.2",
+        )
+        await bot.ask_tool(
+            [{"role": "user", "content": "hi"}],
+            tools=_tool_spec(),
+            reasoning_effort="high",
+        )
+
+    call = mock_manager.chat_with_tools.call_args
+    assert call.kwargs["reasoning_effort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_chatbot_astream_normalizes_anthropic_reasoning_effort():
+    mock_manager = SimpleNamespace(chat_stream=MagicMock(return_value=_AsyncItems([])))
+
+    with patch("spoon_ai.chat.get_llm_manager", return_value=mock_manager):
+        bot = ChatBot(
+            use_llm_manager=True,
+            llm_provider="anthropic",
+            model_name="claude-sonnet-4.6",
+        )
+        chunks = [chunk async for chunk in bot.astream(
+            [{"role": "user", "content": "hi"}],
+            thinking=True,
+            reasoning_effort="high",
+        )]
+
+    assert chunks == []
+    call = mock_manager.chat_stream.call_args
+    assert call.kwargs["thinking"] == {"type": "adaptive"}
+    assert call.kwargs["output_config"] == {"effort": "high"}
 
 
 @pytest.mark.asyncio
@@ -306,9 +442,42 @@ async def test_openrouter_chat_with_tools_streams_reasoning_to_output_queue():
         },
     ]
     assert create_mock.call_args.kwargs["extra_body"]["reasoning"] == {"effort": "low"}
-    assert "thinking" not in create_mock.call_args.kwargs
-    assert response.content == "Done."
-    assert response.metadata.get("streamed_content") is True
+
+
+@pytest.mark.asyncio
+async def test_openrouter_chat_with_tools_maps_reasoning_effort_to_extra_body():
+    provider = OpenRouterProvider()
+    provider.model = "openai/gpt-5"
+    provider.client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=AsyncMock(
+                    return_value=SimpleNamespace(
+                        id="resp_123",
+                        choices=[
+                            SimpleNamespace(
+                                message=SimpleNamespace(content="done", tool_calls=None),
+                                finish_reason="stop",
+                            )
+                        ],
+                        created=123,
+                        usage=None,
+                        model="openai/gpt-5",
+                    )
+                )
+            )
+        )
+    )
+
+    await provider.chat_with_tools(
+        messages=[Message(role="user", content="hi")],
+        tools=_tool_spec(),
+        reasoning_effort="high",
+    )
+
+    assert provider.client.chat.completions.create.call_args.kwargs["extra_body"]["reasoning"] == {
+        "effort": "high"
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- normalize provider-neutral `reasoning_effort` handling inside core so callers do not branch on provider type
- map Anthropic and OpenRouter/OpenAI-compatible request fields consistently for both sync and streaming paths
- add focused regression coverage for provider mapping and streaming normalization

## Test Plan
- `python -m pytest tests/test_tool_streaming_output.py -q -k "reasoning_effort or astream_normalizes_anthropic or maps_anthropic_xhigh"`
- `python -m pytest tests/test_agent_llm_integration.py -q -k "reasoning_effort or forwards_thinking_flag_to_llm"`