### PR TITLE
Avoid false OpenAI stream failures on completed responses

### DIFF
--- a/spoon_ai/agents/spoon_react.py
+++ b/spoon_ai/agents/spoon_react.py
@@ -60,11 +60,13 @@ class SpoonReactAI(MCPClientMixin, ToolCallAgent):
         """Initialize SpoonReactAI with both ToolCallAgent and MCPClientMixin initialization"""
         # Track whether the caller supplied custom prompts so _refresh_prompts()
         # does not overwrite them on init or before run().
-        self._custom_system_prompt = "system_prompt" in kwargs and kwargs["system_prompt"] is not None
-        self._custom_next_step_prompt = "next_step_prompt" in kwargs and kwargs["next_step_prompt"] is not None
+        custom_system_prompt = "system_prompt" in kwargs and kwargs["system_prompt"] is not None
+        custom_next_step_prompt = "next_step_prompt" in kwargs and kwargs["next_step_prompt"] is not None
 
         # Call parent class initializers
         ToolCallAgent.__init__(self, **kwargs)
+        object.__setattr__(self, "_custom_system_prompt", custom_system_prompt)
+        object.__setattr__(self, "_custom_next_step_prompt", custom_next_step_prompt)
 
         # Initialize MCP client mixin
         MCPClientMixin.__init__(self, self.mcp_transport)

--- a/spoon_ai/agents/toolcall.py
+++ b/spoon_ai/agents/toolcall.py
@@ -261,12 +261,13 @@ class ToolCallAgent(ReActAgent):
 
         if self.output_queue:
             if response.content and not streamed_content:
+                pre_tool_content = bool(self.tool_calls)
                 self.output_queue.put_nowait(
                     build_output_queue_event(
-                        event_type="content",
+                        event_type="thinking" if pre_tool_content else "content",
                         delta=response.content,
                         metadata={
-                            "phase": "progress",
+                            "phase": "pre_tool" if pre_tool_content else "final",
                             "source": "toolcall_agent",
                         },
                     )
@@ -711,8 +712,10 @@ class ToolCallAgent(ReActAgent):
         native_finish_reason = getattr(response, 'native_finish_reason', None)
 
         if finish_reason == "stop":
-            # Accept either "stop" (OpenAI) or "end_turn" (Anthropic) as valid termination signals
-            return native_finish_reason in ["stop", "end_turn"]
+            # Accept provider-native successful terminal states that map to
+            # the canonical "stop" finish reason. OpenAI Responses uses the
+            # response status "completed" rather than a chat finish reason.
+            return native_finish_reason in [None, "", "stop", "end_turn", "completed"]
         return False
 
     async def _call_llm_with_middleware(

--- a/spoon_ai/llm/providers/openai_provider.py
+++ b/spoon_ai/llm/providers/openai_provider.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 from datetime import datetime
 from logging import getLogger
+from types import SimpleNamespace
 from typing import Any, AsyncIterator, Dict, List, Optional
 from uuid import uuid4
 
@@ -238,21 +239,25 @@ class OpenAIProvider(OpenAICompatibleProvider):
         return "\n\n".join(parts)
 
     @staticmethod
+    def _responses_tool_call_from_item(item: Any) -> ToolCall | None:
+        if getattr(item, "type", None) != "function_call":
+            return None
+        return ToolCall(
+            id=getattr(item, "call_id", None) or getattr(item, "id", ""),
+            type="function",
+            function=Function(
+                name=getattr(item, "name", None) or "unknown",
+                arguments=getattr(item, "arguments", None) or "{}",
+            ),
+        )
+
+    @staticmethod
     def _extract_responses_tool_calls(response: Any) -> List[ToolCall]:
         tool_calls: List[ToolCall] = []
         for item in getattr(response, "output", []) or []:
-            if getattr(item, "type", None) != "function_call":
-                continue
-            tool_calls.append(
-                ToolCall(
-                    id=getattr(item, "call_id", None) or getattr(item, "id", ""),
-                    type="function",
-                    function=Function(
-                        name=getattr(item, "name", None) or "unknown",
-                        arguments=getattr(item, "arguments", None) or "{}",
-                    ),
-                )
-            )
+            tool_call = OpenAIProvider._responses_tool_call_from_item(item)
+            if tool_call is not None:
+                tool_calls.append(tool_call)
         return tool_calls
 
     @staticmethod
@@ -266,6 +271,74 @@ class OpenAIProvider(OpenAICompatibleProvider):
         if reason == "content_filter":
             return "content_filter"
         return "stop"
+
+    @staticmethod
+    def _responses_native_finish_reason(response: Any, tool_calls: List[ToolCall]) -> str:
+        if tool_calls:
+            return "tool_calls"
+        incomplete = getattr(response, "incomplete_details", None)
+        reason = getattr(incomplete, "reason", None)
+        if reason:
+            return str(reason)
+        status = getattr(response, "status", None)
+        if status:
+            return str(status)
+        return OpenAIProvider._responses_finish_reason(response, tool_calls)
+
+    @staticmethod
+    def _coalesce_responses_terminal_response(
+        *,
+        latest_response: Any | None,
+        model: str,
+        full_content: str,
+        full_reasoning: str,
+        tool_calls: List[ToolCall],
+        fallback_status: str = "incomplete",
+        fallback_reason: str | None = None,
+    ) -> Any | None:
+        if latest_response is not None:
+            return latest_response
+        if not (full_content or full_reasoning or tool_calls):
+            return None
+
+        output: List[Any] = []
+        if full_reasoning:
+            output.append(
+                SimpleNamespace(
+                    type="reasoning",
+                    summary=[SimpleNamespace(text=full_reasoning)],
+                )
+            )
+        if full_content:
+            output.append(
+                SimpleNamespace(
+                    type="message",
+                    content=[SimpleNamespace(type="output_text", text=full_content)],
+                )
+            )
+        for tool_call in tool_calls:
+            output.append(
+                SimpleNamespace(
+                    type="function_call",
+                    id=tool_call.id,
+                    call_id=tool_call.id,
+                    name=tool_call.function.name,
+                    arguments=tool_call.function.arguments,
+                )
+            )
+
+        return SimpleNamespace(
+            id="",
+            created_at=None,
+            model=model,
+            output=output,
+            output_text=full_content,
+            usage=None,
+            status=fallback_status,
+            incomplete_details=(
+                SimpleNamespace(reason=fallback_reason) if fallback_reason else None
+            ),
+        )
 
     @staticmethod
     def _responses_usage(response: Any) -> Dict[str, int] | None:
@@ -287,10 +360,18 @@ class OpenAIProvider(OpenAICompatibleProvider):
         tool_calls = self._extract_responses_tool_calls(response)
         reasoning_text = self._extract_responses_reasoning(response)
         finish_reason = self._responses_finish_reason(response, tool_calls)
+        native_finish_reason = self._responses_native_finish_reason(response, tool_calls)
         metadata = {
             "response_id": getattr(response, "id", ""),
             "created": getattr(response, "created_at", None),
         }
+        status = getattr(response, "status", None)
+        if status:
+            metadata["status"] = status
+        incomplete = getattr(response, "incomplete_details", None)
+        incomplete_reason = getattr(incomplete, "reason", None)
+        if incomplete_reason:
+            metadata["incomplete_reason"] = incomplete_reason
         if reasoning_text:
             metadata["reasoning"] = reasoning_text
 
@@ -299,7 +380,7 @@ class OpenAIProvider(OpenAICompatibleProvider):
             provider=self.get_provider_name(),
             model=getattr(response, "model", self.model),
             finish_reason=finish_reason,
-            native_finish_reason=finish_reason,
+            native_finish_reason=native_finish_reason,
             tool_calls=tool_calls,
             usage=self._responses_usage(response),
             duration=duration,
@@ -476,7 +557,19 @@ class OpenAIProvider(OpenAICompatibleProvider):
 
                 if event_type == "response.completed":
                     latest_response = getattr(event, "response", None)
+                    continue
 
+                if event_type == "response.incomplete":
+                    latest_response = getattr(event, "response", None)
+
+            latest_response = self._coalesce_responses_terminal_response(
+                latest_response=latest_response,
+                model=model,
+                full_content=full_content,
+                full_reasoning=full_reasoning,
+                tool_calls=tool_calls,
+                fallback_reason="stream_ended_without_terminal_event",
+            )
             if latest_response is None:
                 raise RuntimeError("OpenAI Responses stream completed without a final response")
 
@@ -486,11 +579,22 @@ class OpenAIProvider(OpenAICompatibleProvider):
 
             final_tool_calls = self._extract_responses_tool_calls(latest_response) or tool_calls
             finish_reason = self._responses_finish_reason(latest_response, final_tool_calls)
+            native_finish_reason = self._responses_native_finish_reason(
+                latest_response,
+                final_tool_calls,
+            )
             usage = self._responses_usage(latest_response)
             final_metadata: Dict[str, Any] = {
                 "response_id": getattr(latest_response, "id", ""),
                 "created": getattr(latest_response, "created_at", None),
             }
+            status = getattr(latest_response, "status", None)
+            if status:
+                final_metadata["status"] = status
+            incomplete = getattr(latest_response, "incomplete_details", None)
+            incomplete_reason = getattr(incomplete, "reason", None)
+            if incomplete_reason:
+                final_metadata["incomplete_reason"] = incomplete_reason
             if full_reasoning:
                 final_metadata["reasoning"] = full_reasoning
 
@@ -513,7 +617,7 @@ class OpenAIProvider(OpenAICompatibleProvider):
                     provider=self.get_provider_name(),
                     model=getattr(latest_response, "model", model),
                     finish_reason=finish_reason,
-                    native_finish_reason=finish_reason,
+                    native_finish_reason=native_finish_reason,
                     tool_calls=final_tool_calls,
                     usage=usage,
                     duration=duration,
@@ -548,7 +652,9 @@ class OpenAIProvider(OpenAICompatibleProvider):
 
         stream = await self.client.responses.create(**request_kwargs)
         latest_response = None
+        full_content = ""
         full_reasoning = ""
+        tool_calls: List[ToolCall] = []
 
         async for event in stream:
             event_type = getattr(event, "type", None)
@@ -573,6 +679,7 @@ class OpenAIProvider(OpenAICompatibleProvider):
             elif event_type == "response.output_text.delta":
                 delta = getattr(event, "delta", "") or ""
                 if delta:
+                    full_content += delta
                     try:
                         output_queue.put_nowait(
                             build_output_queue_event(
@@ -586,9 +693,23 @@ class OpenAIProvider(OpenAICompatibleProvider):
                         )
                     except Exception:
                         pass
+            elif event_type == "response.output_item.done":
+                tool_call = self._responses_tool_call_from_item(getattr(event, "item", None))
+                if tool_call is not None:
+                    tool_calls.append(tool_call)
             elif event_type == "response.completed":
                 latest_response = getattr(event, "response", None)
+            elif event_type == "response.incomplete":
+                latest_response = getattr(event, "response", None)
 
+        latest_response = self._coalesce_responses_terminal_response(
+            latest_response=latest_response,
+            model=request_kwargs.get("model", self.model),
+            full_content=full_content,
+            full_reasoning=full_reasoning,
+            tool_calls=tool_calls,
+            fallback_reason="stream_ended_without_terminal_event",
+        )
         if latest_response is None:
             raise RuntimeError("OpenAI Responses stream completed without a final response")
 
@@ -596,7 +717,7 @@ class OpenAIProvider(OpenAICompatibleProvider):
         result = self._convert_responses_response(latest_response, duration)
         if full_reasoning:
             result.metadata["reasoning"] = full_reasoning
-        result.metadata["streamed_content"] = bool(result.content)
+        result.metadata["streamed_content"] = bool(full_content or result.content)
         result.metadata["stream_chunk_count"] = 0
         return result
 

--- a/tests/test_agent_llm_integration.py
+++ b/tests/test_agent_llm_integration.py
@@ -57,7 +57,7 @@ class TestAgentLLMIntegration:
         agent = ToolCallAgent(
             name="test_agent",
             llm=mock_chatbot_manager,
-            available_tools=tool_manager
+            available_tools=tool_manager,
         )
         
         # Test agent run
@@ -105,6 +105,31 @@ class TestAgentLLMIntegration:
 
         assert mock_chatbot_manager.ask_tool.await_args.kwargs["thinking"] is True
         assert mock_chatbot_manager.ask_tool.await_args.kwargs["reasoning_effort"] == "high"
+
+    @pytest.mark.asyncio
+    async def test_toolcall_agent_treats_openai_responses_completed_as_terminal(
+        self,
+        mock_chatbot_manager,
+        tool_manager,
+    ):
+        mock_chatbot_manager.ask_tool.return_value = LLMResponse(
+            content="Done.",
+            tool_calls=[],
+            finish_reason="stop",
+            native_finish_reason="completed",
+        )
+
+        agent = ToolCallAgent(
+            name="test_agent",
+            llm=mock_chatbot_manager,
+            available_tools=tool_manager,
+            max_steps=3,
+        )
+
+        result = await agent.run("Test request")
+
+        assert result == "Done."
+        assert mock_chatbot_manager.ask_tool.await_count == 1
 
     @pytest.mark.asyncio
     async def test_toolcall_agent_omits_disabled_thinking_flag_for_llm(self, mock_chatbot_manager, tool_manager):
@@ -170,6 +195,7 @@ class TestAgentLLMIntegration:
             native_finish_reason="tool_calls"
         )
         mock_chatbot_manager.ask_tool.return_value = mock_response
+        mock_chatbot_manager.ask.return_value = "Tool executed successfully"
         
         # Mock tool execution
         tool_manager.execute = AsyncMock(return_value="Tool executed successfully")
@@ -179,7 +205,8 @@ class TestAgentLLMIntegration:
         agent = ToolCallAgent(
             name="test_agent",
             llm=mock_chatbot_manager,
-            available_tools=tool_manager
+            available_tools=tool_manager,
+            max_steps=1,
         )
         
         # Test agent run
@@ -191,6 +218,40 @@ class TestAgentLLMIntegration:
             tool_input={"param": "value"}
         )
         assert "Tool executed successfully" in result
+
+    @pytest.mark.asyncio
+    async def test_toolcall_agent_streams_text_with_tool_calls_as_thinking(self, mock_chatbot_manager, tool_manager):
+        mock_tool_call = ToolCall(
+            id="call_123",
+            type="function",
+            function=Function(
+                name="test_tool",
+                arguments='{"param": "value"}',
+            ),
+        )
+        mock_chatbot_manager.ask_tool.return_value = LLMResponse(
+            content="Need to inspect the file first.",
+            tool_calls=[mock_tool_call],
+            finish_reason="tool_calls",
+            native_finish_reason="tool_calls",
+        )
+
+        agent = ToolCallAgent(
+            name="test_agent",
+            llm=mock_chatbot_manager,
+            available_tools=tool_manager,
+        )
+        await agent.add_message("user", "Use a tool")
+
+        should_act = await agent.think()
+
+        assert should_act is True
+        pre_tool_event = agent.output_queue.get_nowait()
+        assert pre_tool_event["type"] == "thinking"
+        assert pre_tool_event["delta"] == "Need to inspect the file first."
+        assert pre_tool_event["metadata"]["phase"] == "pre_tool"
+        tool_event = agent.output_queue.get_nowait()
+        assert tool_event["tool_calls"] == [mock_tool_call]
 
     @pytest.mark.asyncio
     async def test_toolcall_agent_preserves_tool_call_metadata_in_memory(self, mock_chatbot_manager, tool_manager):
@@ -240,20 +301,14 @@ class TestAgentLLMIntegration:
         assert "reasoning_effort" in inspect.signature(SpoonReactSkill.run).parameters
     
     @pytest.mark.asyncio
-    async def test_spoon_react_ai_fallback_to_legacy(self):
-        """Test SpoonReactAI fallback to legacy mode on initialization failure."""
-        with patch('spoon_ai.agents.spoon_react.create_configured_chatbot') as mock_create:
-            # First call fails (new architecture), second succeeds (legacy)
-            mock_create.side_effect = [
-                Exception("LLM manager initialization failed"),
-                Mock(spec=ChatBot, use_llm_manager=False)
-            ]
-            
-            # This should not raise an exception due to fallback
-            agent = SpoonReactAI(name="spoon_agent")
-            
-            # Verify it fell back to legacy mode
-            assert agent.llm.use_llm_manager is False
+    async def test_spoon_react_ai_accepts_legacy_llm_instance(self):
+        """Test SpoonReactAI can still be constructed with a legacy ChatBot."""
+        mock_chatbot = Mock(spec=ChatBot)
+        mock_chatbot.use_llm_manager = False
+
+        agent = SpoonReactAI(name="spoon_agent", llm=mock_chatbot)
+
+        assert agent.llm.use_llm_manager is False
     
     @pytest.mark.asyncio
     async def test_agent_backward_compatibility(self, mock_chatbot_legacy, tool_manager):
@@ -357,7 +412,7 @@ class TestAgentLLMIntegration:
         assert all(call.args != ({"content": "already streamed full text"},) for call in put_calls)
 
     @pytest.mark.asyncio
-    async def test_toolcall_agent_emits_progress_content_for_non_streamed_pre_tool_content(self, mock_chatbot_manager, tool_manager):
+    async def test_toolcall_agent_emits_thinking_for_non_streamed_pre_tool_content(self, mock_chatbot_manager, tool_manager):
         mock_tool_call = ToolCall(
             id="call_123",
             type="function",
@@ -390,11 +445,11 @@ class TestAgentLLMIntegration:
         assert should_continue is True
         put_calls = mock_queue.put_nowait.call_args_list
         assert put_calls[0].args[0] == {
-            "type": "content",
+            "type": "thinking",
             "delta": "First I will inspect the workspace.",
             "content": "First I will inspect the workspace.",
             "metadata": {
-                "phase": "progress",
+                "phase": "pre_tool",
                 "source": "toolcall_agent",
             },
         }
@@ -539,15 +594,15 @@ class TestAgentLLMIntegration:
     def test_agent_configuration_compatibility(self):
         """Test that agent configuration works with both architectures."""
         # Test with manager architecture
-        with patch('spoon_ai.agents.spoon_react.create_configured_chatbot') as mock_create:
-            mock_chatbot = Mock(spec=ChatBot)
-            mock_chatbot.use_llm_manager = True
-            mock_create.return_value = mock_chatbot
-            
+        mock_chatbot = Mock(spec=ChatBot)
+        mock_chatbot.use_llm_manager = True
+
+        with patch('spoon_ai.agents.spoon_react.create_configured_chatbot'):
             agent_manager = SpoonReactAI(
                 name="manager_agent",
                 max_steps=5,
-                system_prompt="Custom system prompt"
+                system_prompt="Custom system prompt",
+                llm=mock_chatbot,
             )
             
             assert agent_manager.max_steps == 5
@@ -555,15 +610,15 @@ class TestAgentLLMIntegration:
             assert agent_manager.llm.use_llm_manager is True
         
         # Test with legacy architecture
-        with patch('spoon_ai.agents.spoon_react.create_configured_chatbot') as mock_create:
-            mock_chatbot = Mock(spec=ChatBot)
-            mock_chatbot.use_llm_manager = False
-            mock_create.return_value = mock_chatbot
-            
+        mock_chatbot = Mock(spec=ChatBot)
+        mock_chatbot.use_llm_manager = False
+
+        with patch('spoon_ai.agents.spoon_react.create_configured_chatbot'):
             agent_legacy = SpoonReactAI(
                 name="legacy_agent",
                 max_steps=3,
-                system_prompt="Legacy system prompt"
+                system_prompt="Legacy system prompt",
+                llm=mock_chatbot,
             )
             
             assert agent_legacy.max_steps == 3
@@ -580,19 +635,19 @@ class TestAgentMigrationCompatibility:
         # This test ensures that existing agent implementations
         # continue to work without any code changes
         
-        with patch('spoon_ai.agents.spoon_react.create_configured_chatbot') as mock_create:
-            mock_chatbot = Mock(spec=ChatBot)
-            mock_chatbot.use_llm_manager = True
-            mock_chatbot.ask_tool = AsyncMock(return_value=LLMResponse(
-                content="Compatibility test",
-                tool_calls=[],
-                finish_reason="stop",
-                native_finish_reason="stop"
-            ))
-            mock_create.return_value = mock_chatbot
+        mock_chatbot = Mock(spec=ChatBot)
+        mock_chatbot.use_llm_manager = True
+        mock_chatbot.ask_tool = AsyncMock(return_value=LLMResponse(
+            content="Compatibility test",
+            tool_calls=[],
+            finish_reason="stop",
+            native_finish_reason="stop"
+        ))
+
+        with patch('spoon_ai.agents.spoon_react.create_configured_chatbot'):
             
             # Create agent using existing pattern
-            agent = SpoonReactAI(name="compat_agent")
+            agent = SpoonReactAI(name="compat_agent", llm=mock_chatbot)
             
             # Run using existing pattern
             result = await agent.run("Test compatibility")

--- a/tests/test_tool_streaming_output.py
+++ b/tests/test_tool_streaming_output.py
@@ -510,6 +510,112 @@ async def test_openai_chat_with_tools_uses_responses_reasoning_summary_when_effo
 
 
 @pytest.mark.asyncio
+async def test_openai_chat_with_tools_accepts_response_incomplete_terminal_event():
+    provider = OpenAIProvider()
+    provider.model = "gpt-5.4"
+
+    incomplete_response = SimpleNamespace(
+        id="resp_incomplete_123",
+        created_at=223.0,
+        model="gpt-5.4",
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+        output=[
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text="Partial answer")],
+            ),
+        ],
+        usage=SimpleNamespace(
+            input_tokens=10,
+            output_tokens=7,
+            total_tokens=17,
+        ),
+    )
+    stream_items = [
+        SimpleNamespace(
+            type="response.reasoning_summary_text.delta",
+            delta="Plan: keep the partial answer stable.",
+        ),
+        SimpleNamespace(
+            type="response.output_text.delta",
+            delta="Partial answer",
+        ),
+        SimpleNamespace(
+            type="response.incomplete",
+            response=incomplete_response,
+        ),
+    ]
+    provider.client = SimpleNamespace(
+        responses=SimpleNamespace(create=AsyncMock(return_value=_AsyncItems(stream_items))),
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=AsyncMock()),
+        ),
+    )
+
+    q: asyncio.Queue = asyncio.Queue()
+    response = await provider.chat_with_tools(
+        messages=[Message(role="user", content="hi")],
+        tools=_tool_spec(),
+        output_queue=q,
+        reasoning_effort="high",
+    )
+
+    streamed_events: list[dict] = []
+    while not q.empty():
+        streamed_events.append(await q.get())
+
+    assert [event["type"] for event in streamed_events] == ["thinking", "content"]
+    assert response.content == "Partial answer"
+    assert response.finish_reason == "length"
+    assert response.native_finish_reason == "max_output_tokens"
+    assert response.metadata["status"] == "incomplete"
+    assert response.metadata["incomplete_reason"] == "max_output_tokens"
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_with_tools_falls_back_to_streamed_tool_call_when_terminal_event_is_missing():
+    provider = OpenAIProvider()
+    provider.model = "gpt-5.4"
+
+    stream_items = [
+        SimpleNamespace(
+            type="response.output_item.done",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_fallback_123",
+                call_id="call_fallback_123",
+                name="echo_tool",
+                arguments='{"text":"hello"}',
+            ),
+        ),
+    ]
+    provider.client = SimpleNamespace(
+        responses=SimpleNamespace(create=AsyncMock(return_value=_AsyncItems(stream_items))),
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=AsyncMock()),
+        ),
+    )
+
+    q: asyncio.Queue = asyncio.Queue()
+    response = await provider.chat_with_tools(
+        messages=[Message(role="user", content="hi")],
+        tools=_tool_spec(),
+        output_queue=q,
+        reasoning_effort="high",
+    )
+
+    assert q.empty()
+    assert response.finish_reason == "tool_calls"
+    assert response.native_finish_reason == "tool_calls"
+    assert len(response.tool_calls) == 1
+    assert response.tool_calls[0].function.name == "echo_tool"
+    assert response.metadata["status"] == "incomplete"
+    assert response.metadata["incomplete_reason"] == "stream_ended_without_terminal_event"
+
+
+@pytest.mark.asyncio
 async def test_openai_chat_stream_uses_responses_reasoning_summary_when_effort_requested():
     provider = OpenAIProvider()
     provider.model = "gpt-5.4"
@@ -631,6 +737,48 @@ async def test_openai_chat_stream_uses_responses_reasoning_summary_when_effort_r
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_stream_synthesizes_partial_terminal_chunk_when_terminal_event_is_missing():
+    provider = OpenAIProvider()
+    provider.model = "gpt-5.4"
+    provider.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            create=AsyncMock(
+                return_value=_AsyncItems(
+                    [
+                        SimpleNamespace(
+                            type="response.reasoning_summary_text.delta",
+                            delta="Plan: keep working from the partial output.",
+                        ),
+                        SimpleNamespace(
+                            type="response.output_text.delta",
+                            delta="Partial stream result",
+                        ),
+                    ]
+                )
+            )
+        ),
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=AsyncMock()),
+        ),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in provider.chat_stream(
+            messages=[Message(role="user", content="hi")],
+            tools=_tool_spec(),
+            reasoning_effort="high",
+        )
+    ]
+
+    assert chunks[-1].content == "Partial stream result"
+    assert chunks[-1].finish_reason == "stop"
+    assert chunks[-1].metadata["status"] == "incomplete"
+    assert chunks[-1].metadata["incomplete_reason"] == "stream_ended_without_terminal_event"
+    assert chunks[-1].metadata["reasoning"] == "Plan: keep working from the partial output."
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- accept OpenAI Responses `completed` as a successful terminal state when it maps to canonical `stop`
- classify non-streamed text attached to tool-call turns as `thinking/pre_tool` instead of final content
- preserve caller-provided `SpoonReactAI` prompts across initialization and keep integration tests isolated from local `.env`

## Tests
- `python -m py_compile spoon_ai\agents\toolcall.py spoon_ai\agents\spoon_react.py`
- `python -m pytest tests/test_agent_llm_integration.py -q`

## Not included
- local `dist-local/`
- local `pr-body-core.md`
- config or secrets